### PR TITLE
Restore flexbox test for min-height/min-width:auto

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -491,6 +491,8 @@ window.Specs = {
 			"flex-shrink": ["1","10"],
 			"flex-wrap": ["nowrap", "wrap", "wrap-reverse"],
 			"justify-content": ["flex-start", "flex-end", "space-between", "space-around"],
+			"min-height": ["auto"],
+			"min-width": ["auto"],
 			"order": ["0", "1"]
 		}
 	},


### PR DESCRIPTION
This reverts #40.

Backstory: the flexbox spec used to include values "min-height:auto" / "min-width:auto"; then they were removed (hence #40 which removed them here), and they were later restored, so this patch restores them here.

The current spec text on these values is here:
https://drafts.csswg.org/css-flexbox-1/#min-size-auto