### PR TITLE
Add CSS-wide unset value

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -536,7 +536,16 @@ window.Specs = {
 	},
 
 	"css3-cascade": {
-		"title": "Resetting All Properties",
+		"title": "Cascading and Inheritance",
+		"values": {
+			"properties": [
+				"color",
+				"font-weight",
+				"background-image",
+				"width"
+			],
+			"unset": "unset"
+		},
 		"properties": {
 			"all": ["initial", "inherit", "unset"]
 		}


### PR DESCRIPTION
Mentioned in Values and Units but normatively defined in Cascade L3.
Added two properties that inherit (same as inherit) and two that don’t
(same as initial).