### PR TITLE
Grid gap properties uncommented and updated.

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -513,11 +513,10 @@ window.Specs = {
 			"grid-column-end": ["auto", "4", "C", "C 2", "span C", "span 1"],
 			"grid-column": ["auto", "1", "-1", "1 / 1", "1 / -1", "auto / auto", "2 / span 2"],
 			"grid-row": ["auto", "1", "-1", "1 / 1", "1 / -1", "auto / auto", "2 / span 2"],
-			"grid-area": ["1 / 1", "1 / span 1", "span / 10 / -1"]
-			/* These are on their way into the draft spec, currently only in editors draft */
-			// "grid-column-gap": ["normal", "1em"],
-			// "grid-row-gap": ["normal", "1em"],
-			// "grid-gap": ["normal", "normal 1em", "1em", "1em 1em"]
+			"grid-area": ["1 / 1", "1 / span 1", "span / 10 / -1"],
+			"grid-column-gap": ["0", "1em"],
+			"grid-row-gap": ["0", "1em"],
+			"grid-gap": ["normal", "0 1em", "1em", "1em 1em"]
 		}
 	},
 


### PR DESCRIPTION
The `grid-gap`, `grid-column-gap` and `grid-row-gap` properties have now moved from the editors draft to the proposed spec, so might be time to start tracking them.