### PR TITLE
Remove obsolete glyph-orientation-vertical

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -376,7 +376,6 @@ window.Specs = {
 			"unicode-bidi": ["normal", "embed", "isolate", "bidi-override", "isolate-override", "plaintext"],
 			"writing-mode": ["horizontal-tb", "vertical-rl", "vertical-lr"],
 			"text-orientation": ["mixed", "upright", "sideways"],
-			"glyph-orientation-vertical": ["auto", "0deg", "90deg", "0", "90"],
 			"text-combine-upright": ["none", "all", "digits 2"]
 		}
 	},


### PR DESCRIPTION
…it is an old SVG only property, that is marked as obsolete in CSS Writing Modes, and in SVG it is marked as “It has been obsoleted in SVG 2 and partially replaced by the ‘text-orientation’ property of CSS Writing Modes Level 3.”