### PR TITLE
Cascade4

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -552,8 +552,14 @@ window.Specs = {
 	},
 	"css-cascade-4": {
 		"title": "Cascading and Inheritance Level 4",
-		"properties": {
-			"all": ["revert"]
+		"values": {
+			"properties": [
+				"color",
+				"font-weight",
+				"background-image",
+				"all"
+			],
+			"revert": "revert"
 		}
 	},
 	"css3-conditional": {


### PR DESCRIPTION
A previous PR adding revert only added it as a value of ‘all’, so only
applies if that property is supported. I’ve changed it to the real
change, which is adding ‘revert’ as a CSS-wide keyword. I switched out
the last test from ‘width’ to ‘all’ to make sure it works on that
property.