### PR TITLE
Remove css21 from Lists & Counters

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -748,30 +748,6 @@ window.Specs = {
 	"css-lists": {
 		"title": "Lists and Counters",
 		"properties": {
-			"list-style" : [
-				"outside", "disc", "disc outside", "outside disc", "disc none", "none disc", "none disc outside", "none outside disc", "disc none outside", "disc outside none", "outside none disc", "outside disc none", "inside none", "none inside", "none none inside", "square", "none", "none none", "outside none none", "none outside none", "none none outside", "none outside", "outside none", "outside outside", "outside inside", 
-				"\\32 style", "\\32 style inside", '"-"', "'-'", "inside '-'", "'-' outside", "none '-'", "inside none '-'",
-				"symbols(\"*\" \"\\2020\" \"\\2021\" \"\\A7\")",
-				"symbols(cyclic \"*\" \"\\2020\" \"\\2021\" \"\\A7\")",
-				"inside symbols(\"*\" \"\\2020\" \"\\2021\" \"\\A7\")",
-				"symbols(\"*\" \"\\2020\" \"\\2021\" \"\\A7\") outside",
-				"none symbols(\"*\" \"\\2020\" \"\\2021\" \"\\A7\")",
-				"none symbols(\"*\" \"\\2020\" \"\\2021\" \"\\A7\")",
-				"inside none symbols(\"*\" \"\\2020\" \"\\2021\" \"\\A7\")",
-				"inside none symbols(\"*\" \"\\2020\" \"\\2021\" \"\\A7\")",
-				// render problem (too long)
-				/*'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==")',
-				'none url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==")',
-				'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==") none',
-				'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==") outside',
-				'outside url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==")',
-				'outside none url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==")',
-				'outside url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==") none',
-				'none url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==") outside',
-				'none outside url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==")',
-				'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==") outside none',
-				'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==") none outside'*/
-			],
 			"list-style-type": [ 
 				"disclosure-closed", "disclosure-open",
 				"hebrew",

--- a/tests.js
+++ b/tests.js
@@ -773,12 +773,8 @@ window.Specs = {
 				'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKElEQVR42u3NQQ0AAAgEoNP+nTWFDzcoQE1udQQCgUAgEAgEAsGTYAGjxAE/G/Q2tQAAAABJRU5ErkJggg==") none outside'*/
 			],
 			"list-style-type": [ 
-				"disc", "none", "circle", "square", 
 				"disclosure-closed", "disclosure-open",
-				"decimal", "decimal-leading-zero",
-				"lower-roman", "upper-roman", "lower-greek",
-				"lower-alpha", "lower-latin", "upper-alpha", "upper-latin",
-				"hebrew", "armenian", "georgian",
+				"hebrew",
 				"cjk-decimal", "cjk-ideographic",
 				"hiragana", "katakana", "hiragana-iroha", "katakana-iroha",
 				"japanese-informal", "japanese-formal", "korean-hangul-formal",


### PR DESCRIPTION
* Remove CSS2.1 values.
* Remove shorthand as it is the same syntax as CSS2.1 and everything but the list-style-type component is the same.