### PR TITLE
Add Text 4 hyphenation properties

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -284,8 +284,8 @@ window.Specs = {
 		}
 	},
 
-	"css3-text": {
-		"title": "Text",
+	"css-text-3": {
+		"title": "Text Level 3",
 		"properties": {
 			"text-transform": ["full-width"],
 			"tab-size": ["4", "1em"],
@@ -300,6 +300,17 @@ window.Specs = {
 			"word-spacing": ["50%"],
 			"text-indent": ["1em hanging", "1em each-line", "1em hanging each-line"],
 			"hanging-punctuation": ["none", "first", "last", "force-end", "allow-end", "first last"]
+		}
+	},
+    
+    	"css-text-4": {
+		"title": "Text Level 4",
+		"properties": {
+			"hyphenate-character": ["auto", "'\2010'"],
+			"hyphenate-limit-zone": ["1%", "1em"],
+			"hyphenate-limit-chars": ["auto", "5", "auto 3", "5 4 3"],
+			"hyphenate-limit-lines": ["no-limit", "2"],
+			"hyphenate-limit-last": ["none", "always", "column", "page", "spread"]
 		}
 	},
 


### PR DESCRIPTION
Partially supported by Safari and IE10+

I’ve not added the other properties as I don’t think any are supported and some have notes about debate on the names.