### PR TITLE
Update CSS Overflow to Ed Draft

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -798,9 +798,8 @@ window.Specs = {
 		"title": "Overflow",
 		"properties": {
 			"max-lines": ["none", "1"],
-			"overflow": ["paged-x", "paged-y", "paged-x-controls", "paged-y-controls", "fragments"],
-			"overflow-x": ["paged-x", "paged-y", "paged-x-controls", "paged-y-controls", "fragments"],
-			"overflow-y": ["paged-x", "paged-y", "paged-x-controls", "paged-y-controls", "fragments"]
+			"overflow-x": ["visible", "hidden", "clip", "scroll", "auto"],
+			"overflow-y": ["visible", "hidden", "clip", "scroll", "auto"]
 		},
 		"selectors": {
 			"::nth-fragment()": [


### PR DESCRIPTION
All those paged properties no longer exist. I removed the shorthand as
it is now the same as CSS2.1, except the ‘clip’ value, which is well
tested via overflow-x/-y