### PR TITLE
Test unicode-range as a descriptor, not a property.

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -211,6 +211,10 @@ Test.groups = {
 		return Supports.value(property, value);
 	},
 	
+	'descriptors': function(value, descriptor) {
+		return Supports.descriptorvalue(descriptor, value);
+	},
+	
 	'selectors': function(test) {
 		return Supports.selector(test);
 	},

--- a/supports.js
+++ b/supports.js
@@ -92,6 +92,13 @@ var _ = window.Supports = {
 		return false;
 	},
 	
+	descriptorvalue: function(descriptor, value) {
+		/* doesn't handle prefixes for descriptor or value */
+		style.textContent = "@font-face {" + descriptor + ":" + value + "}";
+		return style.sheet.cssRules.length == 1 &&
+		       style.sheet.cssRules[0].style.length == 1;
+	},
+	
 	selector: function(selector) {
 		if(!_.selector.cached) {
 			_.selector.cached = {};

--- a/tests.js
+++ b/tests.js
@@ -371,7 +371,9 @@ window.Specs = {
 			],
 			"font-variant": ["none", "sub lining-nums contextual ruby"],
 			"font-feature-settings": ["normal", "'c2sc'", "'smcp' on", "'liga' off", "'smcp', 'swsh' 2"],
-			"font-language-override": ["normal", "'SRB'"],
+			"font-language-override": ["normal", "'SRB'"]
+		},
+		"descriptors": {
 			"unicode-range": ["U+416", "U+0-7F", "U+A5, U+4E00-9FFF", "U+30??"]
 		},
 		"@rules": {


### PR DESCRIPTION
This implements support for testing whether a value of an @font-face
descriptor is supported.  I've added the code to do this in supports.js,
although it's not clear to me whether I should be adding it there, or
whether you'd rather leave supports.js untouched and add this code
outside of it.

The test for testing descriptors works somewhat differently from other
properties because there isn't any better object model support that's
interoperable.  I've tested locally in Firefox and Chrome that supported
descriptors pass and unsupported descriptors fail.

I didn't add support for prefixing in the tests of descriptor support.
It didn't seem necessary for the unicode-range test, it's extra work,
and I tend to think it's also harmful to promote prefixed support.

This flips the unicode-range tests from red to green on both Firefox and
Chrome.  I haven't tested elsewhere.