### PR TITLE
Missing `image-rendering` property in mage Values and Replaced Content Module Level 3

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -33,7 +33,7 @@ window.Specs = {
 			]
 		}
 	},
-	
+
 	"css-backgrounds-4": {
 		"title": "Backgrounds and Borders Level 4",
 		"properties": {
@@ -88,7 +88,8 @@ window.Specs = {
 			"object-fit": ["fill", "contain", "cover", "none", "scale-down"],
 			"object-position": ["50% 50%", "center", "top right", "bottom 10px right 20px"],
 			"image-resolution": ["from-image", "from-image snap", "snap from-image", "1dppx", "1dpcm", "300dpi", "from-image 300dpi", "300dpi from-image", "300dpi from-image snap"],
-			"image-orientation": ["0deg", "90deg", "45deg", "1turn", "100grad", "2rad"]
+			"image-orientation": ["0deg", "90deg", "45deg", "1turn", "100grad", "2rad"],
+			"image-rendering": ["auto", "crisp-edges", "pixelated"],
 		}
 	},
 
@@ -659,7 +660,7 @@ window.Specs = {
 			"shape-margin": ["0", "10px", "50%"]
 		}
 	},
-	
+
 	"css3-exclusions": {
 		"title": "Exclusions",
 		"properties": {
@@ -681,13 +682,13 @@ window.Specs = {
 			"touch-action": ["auto", "none", "pan-x", "pan-y", "pan-x pan-y", "manipulation"]
 		}
 	},
-	
+
 	"fullscreen": {
 		"title": "Fullscreen API",
 		"selectors": {
 			"::backdrop": "::backdrop",
 			":fullscreen": ":fullscreen"
-		}	
+		}
 	},
 
 	"css3-break": {
@@ -729,10 +730,10 @@ window.Specs = {
 			"display": ["ruby", "ruby-base", "ruby-text", "ruby-base-container", "ruby-text-container"],
 			"ruby-position" : ["over", "under", "inter-character"],
 			"ruby-merge" : ["separate", "collapse", "auto"],
-			"ruby-align" : ["start", "center", "space-between",	"space-around"]			
+			"ruby-align" : ["start", "center", "space-between",	"space-around"]
 		}
 	},
-	
+
 	"css-snappoints": {
 		"title": "Scroll Snap Points",
 		"properties": {
@@ -791,11 +792,11 @@ window.Specs = {
 			"border-image-transform": ["logical", "physical", "rotate"]
 		}
 	},
-	
+
 	"css-lists": {
 		"title": "Lists and Counters",
 		"properties": {
-			"list-style-type": [ 
+			"list-style-type": [
 				"disclosure-closed", "disclosure-open",
 				"hebrew",
 				"cjk-decimal", "cjk-ideographic",


### PR DESCRIPTION
See https://drafts.csswg.org/css-images-3/#the-image-rendering