### PR TITLE
Add css containment

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -845,5 +845,12 @@ window.Specs = {
 				":nth-fragment(-n+1)", ":nth-fragment(3n-1)"
 			]
 		}
+	},
+
+	"css-containment": {
+		"title": "Containment",
+		"properties": {
+			"contain": ["none", "strict", "content", "size", "layout", "style", "paint"]
+		}
 	}
 };


### PR DESCRIPTION
Chrome 52 has an implementation. Firefox has a partial implementation behind the flag `layout.css.contain.enabled`.