### PR TITLE
Remove Selector 4 :only-child

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -149,7 +149,7 @@ window.Specs = {
 		}
 	},
 
-	"selectors4": {
+	"selectors": {
 		"title": "Selectors Level 4",
 		"selectors": {
 			"Descendant combinator": "foo >> bar",

--- a/tests.js
+++ b/tests.js
@@ -149,11 +149,10 @@ window.Specs = {
 		}
 	},
 
-	"selectors": {
+	"selectors4": {
 		"title": "Selectors Level 4",
 		"selectors": {
 			"Descendant combinator": "foo >> bar",
-			":only-child" : ":only-child",
 			":focus-ring" : ":focus-ring",
 			":focus-within" : ":focus-within",
 			":matches": [ ":matches(em, #foo)"],


### PR DESCRIPTION
rename the section selectors4, but dev link is a 404... :\

TR : https://www.w3.org/TR/selectors4/
DEV : https://drafts.csswg.org/selectors/