### PR TITLE
Add transforms with calc values

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -535,6 +535,11 @@ window.Specs = {
 			"attr()": ["attr(data-px)", "attr(data-px px)", "attr(data-px px, initial)"],
 			"calc()": ["calc(1px + 2px)", "calc(5px*2)", "calc(5px/2)", "calc(100%/3 - 2*1em - 2*1px)", "calc(attr(data-px)*2)", "calc(5px - 10px)", "calc(1vw - 1px)", "calc(calc(100%))"],
 			"toggle()": "toggle(1px, 2px)"
+		},
+		"properties": {
+			"transform": [
+				"rotate(calc(15deg + 30deg))"
+			]
 		}
 	},
 


### PR DESCRIPTION
Firefox and Edge do not seem to support `calc()` values in some transforms.

I'm not sure if I should put these into a separate test or into the calc tests and if I should cover every transform function.