### PR TITLE
Delete ":matches()"

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -240,7 +240,6 @@ window.Specs = {
 			":local-link": ":local-link",
 			":target-within": ":target-within",
 			":lang()": [":lang(zh, \"*-hant\")"],
-			":matches()": [":matches(em, #foo)"],
 			":not()": [":not(em, #foo)"],
 			":where()": [":not(em, #foo)", ":where(:not(:hover))"],
 			":is()": [":is(em, #foo)", ":is(:not(:hover))"],


### PR DESCRIPTION
> Renamed :matches() to :is(). (https://github.com/w3c/csswg-drafts/issues/3258)

https://www.w3.org/TR/selectors-4/#changes-2018-02