### PR TITLE
Allowed spec. links for specific features

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -154,15 +154,45 @@ Test.prototype = {
 				inside: this.section
 			});
 
-			var dl = document.createElement('dl'),
-				dt = $.create({
-					tag: 'dt',
-					textContent: feature,
-					tabIndex: '0',
-					inside: dl
-				});
+			var dl = document.createElement('dl');
+			var dtContents = [
+				document.createTextNode(feature)
+			];
 
-			var passed = 0, tests = theseTests[feature];
+			if (theseTests[feature].links) {
+				if (theseTests[feature].links.tr) {
+					dtContents.push($.create({
+						tag: 'a',
+						properties: {
+							href: 'https://www.w3.org/TR/' + this.tests.links.tr + theseTests[feature].links.tr,
+							target: '_blank',
+							textContent: 'TR',
+							className: 'spec-link'
+						}
+					}));
+				}
+
+				if (theseTests[feature].links.dev) {
+					dtContents.push($.create({
+						tag: 'a',
+						properties: {
+							href: devLinkFormat(this.tests.links) + theseTests[feature].links.dev,
+							target: '_blank',
+							textContent: 'DEV',
+							className: 'spec-link'
+						}
+					}));
+				}
+			}
+
+			var dt = $.create({
+				tag: 'dt',
+				tabIndex: '0',
+				contents: dtContents,
+				inside: dl
+			});
+		
+			var passed = 0, tests = theseTests[feature].tests || theseTests[feature];
 
 			tests = tests instanceof Array ? tests : [tests];
 

--- a/style.css
+++ b/style.css
@@ -35,11 +35,13 @@ h1, h2 {
 			font-weight: bold;
 		}
 
-		h1 > .spec-link {
+		.spec-link {
 			display: inline-block;
 			padding: .3em .4em;
 			margin: 0 0 0 .3em;
-			font-size: 50%;
+			line-height: 1;
+			font-family: sans-serif;
+			font-size: 0.9rem;
 			background: hsl(200, 10%, 20%);
 			color: white;
 			border-radius: .3em;
@@ -47,10 +49,18 @@ h1, h2 {
 			text-shadow: 0 .1em .1em black;
 		}
 
-		h1 > .spec-link:hover {
+		.spec-link:hover {
 			background: #f06;
 		}
 
+		dt > .spec-link {
+			display: none;
+			vertical-align: inherit;
+		}
+
+		dt:hover > .spec-link {
+			display: inline-block;
+		}
 body > h1 {
 	position: fixed;
 	left: 0;
@@ -128,10 +138,11 @@ dl {
 	}
 
 dt, dd[class] {
-	padding: .5em;
+	padding: 0 .5em;
 	background: gray;
 	color: white;
 	border-radius: .3em;
+	line-height: 2;
 	text-shadow: 0 -.05em .1em rgba(0,0,0,.5);
 	position: relative;
 }


### PR DESCRIPTION
This change allows to provide specification links for individual features within tests.json. Those links appear when you hover the feature.

The structure of a feature with spec. links then looks like this:

```json
"feature": {
	"links": {
		"tr": "#anchor",
		"dev": "#anchor"
	},
	"tests": "tests"
}
```

This new structure is fully optional and the existing structure will still work as before, so no immediate changes to the features are required. (Though I'll try to come up with a separate patch based on this one to add the spec. links to the features.)

Sebastian