### PR TITLE
Removed -n-1 pseudo-class selector tests

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -6496,7 +6496,7 @@ window.Specs = {
 					":nth-child(n)", ":nth-child(-n)", ":nth-child(0n)",
 					":nth-child(1)", ":nth-child(-1)", ":nth-child(0)",
 					":nth-child(n+1)", ":nth-child(3n+1)", ":nth-child(3n + 1)",
-					":nth-child(-n+1)", ":nth-child(-n-1)", ":nth-child(3n-1)"
+					":nth-child(-n+1)", ":nth-child(3n-1)"
 				]
 			},
 			":nth-last-child()": {
@@ -6509,7 +6509,7 @@ window.Specs = {
 					":nth-last-child(n)", ":nth-last-child(-n)", ":nth-last-child(0n)",
 					":nth-last-child(1)", ":nth-last-child(-1)", ":nth-last-child(0)",
 					":nth-last-child(n+1)", ":nth-last-child(3n+1)", ":nth-last-child(3n + 1)",
-					":nth-last-child(-n+1)", ":nth-last-child(-n-1)", ":nth-last-child(3n-1)"
+					":nth-last-child(-n+1)", ":nth-last-child(3n-1)"
 				]
 			},
 			":nth-of-type()": {
@@ -6522,7 +6522,7 @@ window.Specs = {
 					":nth-of-type(n)", ":nth-of-type(-n)", ":nth-of-type(0n)",
 					":nth-of-type(1)", ":nth-of-type(-1)", ":nth-of-type(0)",
 					":nth-of-type(n+1)", ":nth-of-type(3n+1)", ":nth-of-type(3n + 1)",
-					":nth-of-type(-n+1)", ":nth-of-type(-n-1)", ":nth-of-type(3n-1)"
+					":nth-of-type(-n+1)", ":nth-of-type(3n-1)"
 				]
 			},
 			":nth-last-of-type()": {
@@ -6535,7 +6535,7 @@ window.Specs = {
 					":nth-last-of-type(n)", ":nth-last-of-type(-n)", ":nth-last-of-type(0n)",
 					":nth-last-of-type(1)", ":nth-last-of-type(-1)", ":nth-last-of-type(0)",
 					":nth-last-of-type(n+1)", ":nth-last-of-type(3n+1)", ":nth-last-of-type(3n + 1)",
-					":nth-last-of-type(-n+1)", ":nth-last-of-type(-n-1)", ":nth-last-of-type(3n-1)"
+					":nth-last-of-type(-n+1)", ":nth-last-of-type(3n-1)"
 				]
 			},
 			":last-child": {
@@ -6829,7 +6829,7 @@ window.Specs = {
 					":nth-col(n)", ":nth-col(-n)", ":nth-col(0n)",
 					":nth-col(1)", ":nth-col(-1)", ":nth-col(0)",
 					":nth-col(n+1)", ":nth-col(3n+1)", ":nth-col(3n + 1)",
-					":nth-col(-n+1)", ":nth-col(-n-1)", ":nth-col(3n-1)"
+					":nth-col(-n+1)", ":nth-col(3n-1)"
 				]
 			},
 			":nth-last-col()": {
@@ -6842,7 +6842,7 @@ window.Specs = {
 					":nth-last-col(n)", ":nth-last-col(-n)", ":nth-last-col(0n)",
 					":nth-last-col(1)", ":nth-last-col(-1)", ":nth-last-col(0)",
 					":nth-last-col(n+1)", ":nth-last-col(3n+1)", ":nth-last-col(3n + 1)",
-					":nth-last-col(-n+1)", ":nth-last-col(-n-1)", ":nth-last-col(3n-1)"
+					":nth-last-col(-n+1)", ":nth-last-col(3n-1)"
 				]
 			},
 			"[att^=val i]": {


### PR DESCRIPTION
I have removed all -n-1 pseudo-class selector tests as requested in #22.

I have created a PR instead of just merging it, because you (Lea) previously questioned whether this change should be done. I personally agree with the reporter of that issue that `-n-1` is not used in the wild, suspectedly even not for feature detection, because you normally test for something you will use later on in your declarations.

Sebastian