### PR TITLE
Update a few assets to be fetched over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,10 @@
 </aside>
 
 <footer>
-	<a id="mark" href="http://lea.verou.me"><img src="http://lea.verou.me/mark.svg" title="Lea Verou was here" alt="Lea Verou was here" /></a>
+	<a id="mark" href="https://lea.verou.me"><img src="https://lea.verou.me/mark.svg" title="Lea Verou was here" alt="Lea Verou was here" /></a>
 	<p>
-		<a href="http://www.browserscope.org/user/tests/table/agt1YS1wcm9maWxlcnINCxIEVGVzdBidzawNDA" target="_blank">Results</a>
-		&#10047; Handcrafted by <a href="http://lea.verou.me">Lea Verou</a>
+		<a href="https://www.browserscope.org/user/tests/table/agt1YS1wcm9maWxlcnINCxIEVGVzdBidzawNDA" target="_blank">Results</a>
+		&#10047; Handcrafted by <a href="https://lea.verou.me">Lea Verou</a>
 		&#10047; <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&amp;business=lea%40verou%2eme&amp;lc=GR&amp;item_name=Lea%20Verou&amp;currency_code=EUR&amp;bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted">Donate</a></p>
 </footer>
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@ body {
 	max-width: 60em;
 	padding: 1em;
 	margin: auto;
-	background: url(http://dabblet.com/img/noise.png) hsl(24, 20%, 95%);
+	background: url(https://dabblet.com/img/noise.png) hsl(24, 20%, 95%);
 	font: 100%/1.5 sans-serif;
 	text-shadow: 0 1px white;
 }


### PR DESCRIPTION
I know this is a very old project, but anyway - stumbled upon it again, and got shouted at by a browser ("This site is not secure" or similar) because the logo mark and the background image are fetched via `http://`, hence this PR.

According to the Network tab in Firefox 70 those were the only two resources being fetched over http.

I also changed a couple of link destinations to use https while I was at it.

- [x] I've checked that those resources are in fact fetchable via `https://` as well.

