### PR TITLE
Add tests for SVG 2 Geometry Properties

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -44,6 +44,9 @@ var devLinkFormat = function (params) {
 			return 'https://drafts.css-houdini.org/' + params.dev;
 		case "github":
 			return 'https://w3c.github.io/' + params.dev;
+		case "svgwg":
+			// SVG Working Group Editor Drafts
+			return 'https://svgwg.org/' + params.dev;
 		case "whatwg":
 			// WHATWG
 			return 'https://' + params.dev + '.spec.whatwg.org/';
@@ -191,7 +194,7 @@ Test.prototype = {
 				contents: dtContents,
 				inside: dl
 			});
-		
+
 			var passed = 0, tests = theseTests[feature].tests || theseTests[feature];
 
 			tests = tests instanceof Array ? tests : [tests];

--- a/tests.js
+++ b/tests.js
@@ -5385,5 +5385,83 @@ window.Specs = {
 				"tests": ["0.5", "45%"]
 			}
 		}
+	},
+
+	"svg-geometry": {
+		"title": "SVG Geometry",
+		"links": {
+			"tr": "svg2/geometry.html",
+			"dev": "svg2-draft/geometry.html",
+			"devtype": "svgwg"
+		},
+		"properties": {
+			"cx": {
+				"links": {
+					"tr": "#CX",
+					"dev": "#CX"
+				},
+				"tests": ["0", "1px", "-5px", "25%"]
+			},
+			"cy": {
+				"links": {
+					"tr": "#CY",
+					"dev": "#CY"
+				},
+				"tests": ["0", "1px", "-5px", "25%"]
+			},
+			"r": {
+				"links": {
+					"tr": "#R",
+					"dev": "#R"
+				},
+				"tests": ["0", "1px", "25%"]
+			},
+			"rx": {
+				"links": {
+					"tr": "#RX",
+					"dev": "#RX"
+				},
+				"tests": ["auto", "0", "1px", "25%"]
+			},
+			"ry": {
+				"links": {
+					"tr": "#RY",
+					"dev": "#RY"
+				},
+				"tests": ["auto", "0", "1px", "25%"]
+			},
+			"x": {
+				"links": {
+					"tr": "#X",
+					"dev": "#X"
+				},
+				"tests": ["0", "1px", "-5px", "25%"]
+			},
+			"y": {
+				"links": {
+					"tr": "#Y",
+					"dev": "#Y"
+				},
+				"tests": ["0", "1px", "-5px", "25%"]
+			}
+		}
+	},
+
+	"svg-paths": {
+		"title": "SVG Paths",
+		"links": {
+			"tr": "svg2/paths.html",
+			"dev": "svg2-draft/paths.html",
+			"devtype": "svgwg"
+		},
+		"properties": {
+			"d": {
+				"links": {
+					"tr": "#TheDProperty",
+					"dev": "#TheDProperty"
+				},
+				"tests": ["none", "'M 20 20 H 80 V 30'"]
+			}
+		}
 	}
 };


### PR DESCRIPTION
These properties are defined in the SVG2 spec.
All properties except `d` are supported in all major browsers.

