### PR TITLE
Update for changes to color()

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -2591,11 +2591,22 @@ window.Specs = {
 				},
 				"tests": [
 					"color(.2 .4 .6)",
-					"color(image-p3 .2. 4 .6)",
+					"color(display-p3 .2. 4 .6)",
 					"color(foo .2 .4 .6)",
 					"color(.2 .4 .6 / .5)",
-					"color(image-p3 .2 .4 .6  / .5)",
-					"color(foo .2 .4 .6 / .5)"
+					"color(display-p3 .2 .4 .6  / .5)",
+					"color(--foo .2 .4 .6 / .5)",
+					"color(.2 .4 .6, #123456)",
+					"color(display-p3 .2. 4 .6, #654321)",
+					"color(20% 40% 60%)",
+					"color(display-p3 20% 40% 60%)",
+					"color(foo 20% 40% 60%)",
+					"color(20% 40% 60% / .5)",
+					"color(image-p3 20% 40% 60%  / .5)",
+					"color(--foo 20% 40% 60% / .5)",
+					"color(20% 40% 60%, #123456)",
+					"color(display-p3 20% 40% 60%, #654321)",
+					"color(--mycmyk 0% 20% 30% 5%)"
 				]
 			},
 			"device-cmyk()": {


### PR DESCRIPTION
Several [changes to the `color()` function](https://drafts.csswg.org/css-color-4/#color-function) since the test was first added:

- `color()` can take either number [0..1] or percent [0%..100%]
- `image-p3` was renamed `display-p3` by request from Apple
- parameters not limited to 3, e.g. 4 for a cmyk space
- non-predefined colorspaces are now `dashed-ident` like --foo
- comma separated list of fallback colors after the main color