### PR TITLE
Support complete @rules

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,8 +38,7 @@ h1, h2 {
 		.spec-link {
 			display: inline-block;
 			padding: .3em .4em;
-			margin: 0 0 0 .3em;
-			line-height: 1;
+			margin: -.5em 0 -.5em .3em;
 			font-family: sans-serif;
 			font-size: 0.9rem;
 			background: hsl(200, 10%, 20%);
@@ -138,11 +137,10 @@ dl {
 	}
 
 dt, dd[class] {
-	padding: 0 .5em;
+	padding: .5em;
 	background: gray;
 	color: white;
 	border-radius: .3em;
-	line-height: 2;
 	text-shadow: 0 -.05em .1em rgba(0,0,0,.5);
 	position: relative;
 }
@@ -218,6 +216,7 @@ dl > dd {
 
 dl.open > dd {
 	display: block;
+	white-space: pre;
 }
 
 /* Emoticons */

--- a/supports.js
+++ b/supports.js
@@ -135,7 +135,7 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 			for (var i = 0; i < _.prefixes.length; i++) {
 				var prefixed = atrule.replace(/^@/, '@' + _.prefixes[i]);
 
-				style.textContent = prefixed + '{}';  // Safari 4 has issues with style.innerHTML
+				style.textContent = prefixed;  // Safari 4 has issues with style.innerHTML
 
 				if (style.sheet.cssRules.length > 0) {
 					return _.atrule.cached[atrule] = prefixed;

--- a/tests.js
+++ b/tests.js
@@ -1542,7 +1542,7 @@ window.Specs = {
 					"tr": "#keyframes",
 					"dev": "#keyframes"
 				},
-				"tests": "@keyframes foo"
+				"tests": "@keyframes foo {\n  from: {\n    color: blue;\n  }\n  to: {\n    color: red;\n  }\n}"
 			}
 		}
 	},
@@ -2276,7 +2276,7 @@ window.Specs = {
 					"tr": "#font-face-rule",
 					"dev": "#font-face-rule"
 				},
-				"tests": "@font-face"
+				"tests": "@font-face {\n  font-family: foo;\n  src: local('Arial');\n}"
 			}
 		}
 	},
@@ -2362,14 +2362,14 @@ window.Specs = {
 					"tr": "#font-feature-values",
 					"dev": "#font-feature-values"
 				},
-				"tests": "@font-feature-values Jupiter Sans"
+				"tests": "@font-feature-values Jupiter Sans {\n  @styleset {\n    some-style: 1;\n  }\n}"
 			},
 			"@font-palette-values": {
 				"links": {
 					"tr": "#font-palette-values",
 					"dev": "#font-palette-values"
 				},
-				"tests": "@font-palette-values Augusta"
+				"tests": "@font-palette-values Augusta {\n  font-family: Handover Sans;\n  base-palette: 3;\n}"
 			}
 		}
 	},
@@ -3398,12 +3398,12 @@ window.Specs = {
 					"dev": "#at-supports"
 				},
 				"tests": [
-					"@supports (color: green)",
-					"@supports not (foo: bar)",
-					"@supports (color: green) or (color: red)",
-					"@supports (color: green) and (color: red)",
-					"@supports (color: green) and (not (foo: bar))",
-					"@supports (color: green) or (not (foo: bar))"
+					"@supports (color: green) {}",
+					"@supports not (foo: bar) {}",
+					"@supports (color: green) or (color: red) {}",
+					"@supports (color: green) and (color: red) {}",
+					"@supports (color: green) and (not (foo: bar)) {}",
+					"@supports (color: green) or (not (foo: bar)) {}"
 				]
 			}
 		}
@@ -3422,9 +3422,9 @@ window.Specs = {
 					"dev": "#at-supports-ext"
 				},
 				"tests": [
-					"@supports selector(::before)",
-					"@supports not selector(::-webkit-unknown-pseudo)",
-					"@supports selector(div, div)"
+					"@supports selector(::before) {}",
+					"@supports not selector(::-webkit-unknown-pseudo) {}",
+					"@supports selector(div, div) {}"
 				]
 			}
 		}
@@ -4792,7 +4792,7 @@ window.Specs = {
 					"tr": "#the-counter-style-rule",
 					"dev": "#the-counter-style-rule"
 				},
-				"tests": "@counter-style foo"
+				"tests": "@counter-style foo {\n  system: numeric;\n  symbols: '0' '1' '2' '3' '4' '5' '6' '7' '8' '9';\n}"
 			}
 		}
 	},


### PR DESCRIPTION
This makes it so that at-rules are checked including their descriptors, fixing issue #185.

In order to do proper checks, I've added complete rule declarations for all at-rules and adjusted the CSS so that multiple lines can be shown as values.