### PR TITLE
Show prefixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -219,6 +219,19 @@ dl.open > dd {
 	white-space: pre;
 }
 
+.prefix {
+	display: inline-block;
+	padding: .3em .4em;
+	margin: -.5em 0 -.5em .3em;
+	font-family: sans-serif;
+	font-size: 0.7rem;
+	background: hsla(0, 0%, 0%, 0.3);
+	color: white;
+	border-radius: .3em;
+	vertical-align: middle;
+	text-shadow: 0 .1em .1em black;
+}
+
 /* Emoticons */
 
 dt:after,

--- a/supports.js
+++ b/supports.js
@@ -46,33 +46,51 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 
 		property: function (property) {
 			if (property.charAt(0) === '-') {
-				return camelCase(property) in inline ? property : false;
+				return {
+					success: camelCase(property) in inline ? true : false,
+					property: property
+				};
 			}
 
 			if (!_.property.cached) {
 				_.property.cached = {};
 			}
 			else if (_.property.cached[property]) {
-				return _.property.cached[property];
+				return {
+					success: true,
+					property: _.property.cached[property],
+					prefix: i > 0
+				};
 			}
 
 			for (var i = 0; i < _.prefixes.length; i++) {
 				var prefixed = _.prefixes[i] + property;
 
 				if (camelCase(prefixed) in inline) {
-					return _.property.cached[property] = prefixed;
+					_.property.cached[property] = prefixed;
+					return {
+						success: true,
+						property: prefixed,
+						prefix: _.prefixes[i]
+					};
 				}
 			}
 
-			return _.property.cached[property] = false;
+			_.property.cached[property] = false;
+			return {
+				success: false,
+				property: property
+			};
 		},
 
 		value: function (property, value) {
 			property = _.property(property);
 
-			if (!property) { return false; }
-
-			property = camelCase(property);
+			if (!property.success) {
+				return property;
+			}
+			propertyPrefix = property.prefix
+			property = camelCase(property.property);
 
 			inline.cssText = '';
 			inline[property] = '';
@@ -85,21 +103,29 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 				} catch (e) { }
 
 				if (inline.length > 0) {
-					return prefixed;
+					return {
+						success: true,
+						prefix: _.prefixes[i],
+						propertyPrefix: propertyPrefix
+					};
 				}
 			}
 
-			return false;
+			return {
+				success: false
+			};
 		},
 
 		descriptorvalue: function (descriptor, value) {
 			/* doesn't handle prefixes for descriptor or value */
 			style.textContent = "@font-face {" + descriptor + ":" + value + "}";
 			try {
-				return style.sheet.cssRules.length == 1 &&
-					style.sheet.cssRules[0].style.length == 1;
+				return {
+					success: style.sheet.cssRules.length == 1
+						&& style.sheet.cssRules[0].style.length == 1
+				};
 			} catch (e) {
-				return false;
+				return { success: false };
 			}
 		},
 
@@ -108,7 +134,9 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 				_.selector.cached = {};
 			}
 			else if (_.selector.cached[selector]) {
-				return _.selector.cached[selector];
+				return {
+					success: _.selector.cached[selector]
+				};
 			}
 
 			for (var i = 0; i < _.prefixes.length; i++) {
@@ -116,12 +144,17 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 
 				try {
 					document.querySelector(prefixed);
-					return _.selector.cached[selector] = prefixed;
+					_.selector.cached[selector] = true;
+					return {
+						success: true,
+						prefix: _.prefixes[i]
+					};
 				}
 				catch (e) { }
 			}
 
-			return _.selector.cached[selector] = false;
+			_.selector.cached[selector] = false;
+			return { success: false };
 		},
 
 		atrule: function (atrule) {
@@ -129,7 +162,9 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 				_.atrule.cached = {};
 			}
 			else if (_.atrule.cached[atrule]) {
-				return _.atrule.cached[atrule];
+				return {
+					success: _.atrule.cached[atrule]
+				};
 			}
 
 			for (var i = 0; i < _.prefixes.length; i++) {
@@ -138,30 +173,39 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 				style.textContent = prefixed;  // Safari 4 has issues with style.innerHTML
 
 				if (style.sheet.cssRules.length > 0) {
-					return _.atrule.cached[atrule] = prefixed;
+					_.atrule.cached[atrule] = true;
+					return {
+						success: true,
+						prefix: _.prefixes[i]
+					};
 				}
 			}
 
-
-
-			return _.atrule.cached[atrule] = false;
+			_.atrule.cached[atrule] = false;
+			return { success: false };
 		},
 
 		mq: function (mq) {
 			if (window.matchMedia) {
-				return matchMedia(mq).media !== 'invalid'
-					? true
-					: matchMedia('not ' + mq).media !== 'invalid';
+				return {
+					success: matchMedia(mq).media !== 'invalid'
+						? true
+						: matchMedia('not ' + mq).media !== 'invalid'
+				};
 			}
 			else {
 				style.textContent = '@media ' + mq + '{ foo {} }';
 
 				if (style.sheet.cssRules.length > 0) {
-					return true
+					return {
+						success: true
+					};
 				} else {
 					style.textContent = '@media not ' + mq + '{ foo {} }';
 
-					return style.sheet.cssRules.length > 0 ? mq : false;
+					return {
+						success: style.sheet.cssRules.length > 0 ? mq : false
+					};
 				};
 			}
 		},
@@ -170,15 +214,19 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 			inline.setProperty(name, value);
 			inline.setProperty('margin-right', 'var(' + name + ')');
 			var styles = window.getComputedStyle(dummy);
-			return styles.marginRight === value;
+			return {
+				success: styles.marginRight === value
+			};
 		},
 
 		declaration: function (intruction) {
 			var val = intruction.match(/\s*([^:]+)\s*:\s*(.+)\s*/);
-			return !val[1].match(/--.*/)
-				? Supports.value(val[1], val[2])
-				: Supports.variable(val[1], val[2])
-		},
+			return {
+				success: !val[1].match(/--.*/)
+					? Supports.value(val[1], val[2]).success
+					: Supports.variable(val[1], val[2]).success
+			};
+		}
 	};
 
 	/**

--- a/supports.js
+++ b/supports.js
@@ -147,7 +147,7 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 					_.selector.cached[selector] = true;
 					return {
 						success: true,
-						prefix: _.prefixes[i]
+						propertyPrefix: _.prefixes[i]
 					};
 				}
 				catch (e) { }


### PR DESCRIPTION
I propose this change to show the prefixes in the results:

On selectors:
![Capture d’écran du 2020-10-07 03-24-57](https://user-images.githubusercontent.com/3032555/95276891-b872cc80-084c-11eb-8b50-5cbda3a09c63.png)

On properties:
![Capture d’écran du 2020-10-07 03-19-17](https://user-images.githubusercontent.com/3032555/95276727-48644680-084c-11eb-9de8-a500cf540937.png)

On values:
![Capture d’écran du 2020-10-07 03-20-16](https://user-images.githubusercontent.com/3032555/95276719-44382900-084c-11eb-8202-e91006957967.png)