### PR TITLE
Update Box Sizing Module Levels 3 and 4

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -4993,49 +4993,49 @@ window.Specs = {
 					"tr": "#preferred-size-properties",
 					"dev": "#preferred-size-properties"
 				},
-				"tests": ["stretch", "max-content", "min-content", "fit-content", "fit-content(10%)"]
+				"tests": ["max-content", "min-content", "fit-content(10%)"]
 			},
 			"min-width": {
 				"links": {
 					"tr": "#min-size-properties",
 					"dev": "#min-size-properties"
 				},
-				"tests": ["stretch", "max-content", "min-content", "fit-content", "fit-content(10%)"]
+				"tests": ["max-content", "min-content", "fit-content(10%)"]
 			},
 			"max-width": {
 				"links": {
 					"tr": "#max-size-properties",
 					"dev": "#max-size-properties"
 				},
-				"tests": ["stretch", "max-content", "min-content", "fit-content", "fit-content(10%)"]
+				"tests": ["max-content", "min-content", "fit-content(10%)"]
 			},
 			"height": {
 				"links": {
 					"tr": "#preferred-size-properties",
 					"dev": "#preferred-size-properties"
 				},
-				"tests": ["stretch", "max-content", "min-content", "fit-content", "fit-content(10%)"]
+				"tests": ["max-content", "min-content", "fit-content(10%)"]
 			},
 			"min-height": {
 				"links": {
 					"tr": "#min-size-properties",
 					"dev": "#min-size-properties"
 				},
-				"tests": ["stretch", "max-content", "min-content", "fit-content", "fit-content(10%)"]
+				"tests": ["max-content", "min-content", "fit-content(10%)"]
 			},
 			"max-height": {
 				"links": {
 					"tr": "#max-size-properties",
 					"dev": "#max-size-properties"
 				},
-				"tests": ["stretch", "max-content", "min-content", "fit-content", "fit-content(10%)"]
+				"tests": ["max-content", "min-content", "fit-content(10%)"]
 			},
 			"column-width": {
 				"links": {
 					"tr": "#column-sizing",
 					"dev": "#column-sizing"
 				},
-				"tests": ["stretch", "max-content", "min-content", "fit-content", "fit-content(10%)"]
+				"tests": ["max-content", "min-content", "fit-content(10%)"]
 			}
 		}
 	},
@@ -5058,6 +5058,48 @@ window.Specs = {
 					"dev": "#intrinsic-size-override"
 				},
 				"tests": ["none", "10px", "10px 15px"]
+			},
+			"width": {
+				"links": {
+					"tr": "#sizing-values",
+					"dev": "#sizing-values"
+				},
+				"tests": ["stretch", "fit-content", "contain"]
+			},
+			"min-width": {
+				"links": {
+					"tr": "#sizing-values",
+					"dev": "#sizing-values"
+				},
+				"tests": ["stretch", "fit-content", "contain"]
+			},
+			"max-width": {
+				"links": {
+					"tr": "#sizing-values",
+					"dev": "#sizing-values"
+				},
+				"tests": ["stretch", "fit-content", "contain"]
+			},
+			"height": {
+				"links": {
+					"tr": "#sizing-values",
+					"dev": "#sizing-values"
+				},
+				"tests": ["stretch", "fit-content", "contain"]
+			},
+			"min-height": {
+				"links": {
+					"tr": "#sizing-values",
+					"dev": "#sizing-values"
+				},
+				"tests": ["stretch", "fit-content", "contain"]
+			},
+			"max-height": {
+				"links": {
+					"tr": "#sizing-values",
+					"dev": "#sizing-values"
+				},
+				"tests": ["stretch", "fit-content", "contain"]
 			}
 		}
 	},

--- a/tests.js
+++ b/tests.js
@@ -5052,29 +5052,12 @@ window.Specs = {
 				},
 				"tests": ["auto", "2", "16 / 9", "auto 16 / 9"]
 			},
-			"intrinsic-block-size": {
-				"links": {
+			"contain-intrinsic-size": {
+				"links:" {
+					"tr": "#intrinsic-size-override",
 					"dev": "#intrinsic-size-override"
 				},
-				"tests": ["legacy", "auto", "10px"]
-			},
-			"intrinsic-inline-size": {
-				"links": {
-					"dev": "#intrinsic-size-override"
-				},
-				"tests": ["legacy", "auto", "10px"]
-			},
-			"intrinsic-height": {
-				"links": {
-					"dev": "#intrinsic-size-override"
-				},
-				"tests": ["legacy", "auto", "10px"]
-			},
-			"intrinsic-width": {
-				"links": {
-					"dev": "#intrinsic-size-override"
-				},
-				"tests": ["legacy", "auto", "10px"]
+				"tests": ["none", "10px", "10px 15px"]
 			}
 		}
 	},


### PR DESCRIPTION
This PR adds the new `contain-intrisic-size` property, removes some properties that are no longer in the spec, and move some keywords from *Level 3* to *Level 4* (except for `column-width`).

(spec links: https://drafts.csswg.org/css-sizing-3/ and https://drafts.csswg.org/css-sizing-4/)