### PR TITLE
Avoid NaN score if values are tested again unsupported properties.

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -328,7 +328,7 @@ Test.groups = {
 			}
 		}
 
-		success = 1 - failed.length / properties.length;
+		success = properties.length == 0 ? 0 : 1 - failed.length / properties.length;
 
 		return {
 			success: success,


### PR DESCRIPTION
The recently added Fragmentation Level 4 group causes Flow browser's overall score to display 'NaN'. This is because it tests values against a properties that are not supported, unlike every other group in the test suite.

Test.groups() loops through the list of properties, and as none are supported, removes them from the list. This means properties.length is zero. failed.length is also zero.

'success' now depends on a division by zero, which is NaN, which propagates up to the overall score at the top of the page.

Flow reports a correct %age for every other group, but because the overall score depends on NaN, it itself becomes NaN.

I can work around it by adding 'break-before' or 'break-after' to Flow, but with no supported values, but I think it's better to fix in css3test.