### PR TITLE
Added rest of CSS 2 features

### DIFF
--- a/supports.js
+++ b/supports.js
@@ -142,7 +142,7 @@ window.matchMedia = window.matchMedia || (function (doc, undefined) {
 				if (style.sheet.cssRules.length) {
 					return {
 						success:
-							style.sheet.cssRules[pos].style && style.sheet.cssRules[pos].style.length === 1 ||
+							style.sheet.cssRules[pos].style && style.sheet.cssRules[pos].style.length >= 1 ||
 							!!style.sheet.cssRules[pos][camelCase(descriptor)]
 					};
 				} else {

--- a/tests.js
+++ b/tests.js
@@ -653,15 +653,68 @@ window.Specs = {
 				},
 				"tests": [
 					"@page { margin: 2cm; }",
-					"@page { margin-top: 2cm; }",
-					"@page { margin-right: 2cm; }",
-					"@page { margin-bottom: 2cm; }",
-					"@page { margin-left: 2cm; }",
 					"@page :left { margin: 2cm; }",
 					"@page :right { margin: 2cm; }",
 					"@page :first { margin: 2cm; }"
 				]
 			}
+		},
+		"descriptors": {
+			"@page/margin": {
+				"links": {
+					"tr": "#page-box",
+					"dev": "#page-box"
+				},
+				"tests": [
+					"2cm",
+					"4%",
+					"auto"
+				]
+			},
+			"@page/margin-top": {
+				"links": {
+					"tr": "#page-box",
+					"dev": "#page-box"
+				},
+				"tests": [
+					"2cm",
+					"4%",
+					"auto"
+				]
+			},
+			"@page/margin-right": {
+				"links": {
+					"tr": "#page-box",
+					"dev": "#page-box"
+				},
+				"tests": [
+					"2cm",
+					"4%",
+					"auto"
+				]
+			},
+			"@page/margin-bottom": {
+				"links": {
+					"tr": "#page-box",
+					"dev": "#page-box"
+				},
+				"tests": [
+					"2cm",
+					"4%",
+					"auto"
+				]
+			},
+			"@page/margin-left": {
+				"links": {
+					"tr": "#page-box",
+					"dev": "#page-box"
+				},
+				"tests": [
+					"2cm",
+					"4%",
+					"auto"
+				]
+			},
 		},
 		"properties": {
 			"orphans": {

--- a/tests.js
+++ b/tests.js
@@ -331,6 +331,32 @@ window.Specs = {
 		}
 	},
 
+	"css2-cascade": {
+		"title": "CSS 2 Assigning property values, Cascading, and Inheritance",
+		"links": {
+			"tr": "CSS22/cascade.html",
+			"dev": "css2/"
+		},
+		"status": {
+			"stability": "stable",
+			"first-snapshot": 1998,
+			"last-snapshot": 1998
+		},
+		"values": {
+			"properties": [
+				"color",
+				"border-color"
+			],
+			"inherit": {
+				"links": {
+					"tr": "#value-def-inherit",
+					"dev": "#value-def-inherit"
+				},
+				"tests": "inherit"
+			}
+		}
+	},
+
 	"css2-colors": {
 		"title": "CSS 2 Colors and Backgrounds",
 		"links": {
@@ -564,6 +590,31 @@ window.Specs = {
 		}
 	},
 
+
+	"css2-media": {
+		"title": "CSS 2 Media types",
+		"links": {
+			"tr": "CSS22/media.html",
+			"dev": "css2/"
+		},
+		"status": {
+			"stability": "stable",
+			"first-snapshot": 1998,
+			"last-snapshot": 1998
+		},
+		"@rules": {
+			"@media": {
+				"links": {
+					"tr": "#at-media-rule",
+					"dev": "#at-media-rule"
+				},
+				"tests": [
+					"@media print { color: green; }", "@media print, screen { color: green; }"
+				]
+			}
+		}
+	},
+
 	"css2-page": {
 		"title": "CSS 2 Paged Media",
 		"links": {
@@ -574,6 +625,21 @@ window.Specs = {
 			"stability": "stable",
 			"first-snapshot": 1998,
 			"last-snapshot": 1998
+		},
+		"@rules": {
+			"@page": {
+				"links": {
+					"tr": "#page-box",
+					"dev": "#page-box"
+				},
+				"tests": [
+					"@page { margin: 2cm; }",
+					"@page :left { margin: 2cm; }",
+					"@page :right { margin: 2cm; }",
+					"@page :first { margin: 2cm; }",
+					"@page :blank { margin: 2cm; }"
+				]
+			}
 		},
 		"properties": {
 			"orphans": {
@@ -610,6 +676,150 @@ window.Specs = {
 					"dev": "#break-inside"
 				},
 				"tests": ["1", "2"]
+			}
+		}
+	},
+
+	"css2-selectors": {
+		"title": "CSS 2 Selectors",
+		"links": {
+			"tr": "CSS22/selectors.html",
+			"dev": "css2/"
+		},
+		"status": {
+			"stability": "stable",
+			"first-snapshot": 1998,
+			"last-snapshot": 1998
+		},
+		"selectors": {
+			"Universal selector": {
+				"links": {
+					"tr": "#universal-selector",
+					"dev": "#universal-selector"
+				},
+				"tests": "*"
+			},
+			"Type selector": {
+				"links": {
+					"tr": "#type-selectors",
+					"dev": "#type-selectors"
+				},
+				"tests": "h1"
+			},
+			"Descendant selector": {
+				"links": {
+					"tr": "#descendant-selectors",
+					"dev": "#descendant-selectors"
+				},
+				"tests": "div p"
+			},
+			"Child selector": {
+				"links": {
+					"tr": "#child-selectors",
+					"dev": "#child-selectors"
+				},
+				"tests": "div > p"
+			},
+			"Adjacent sibling selector": {
+				"links": {
+					"tr": "#adjacent-selectors",
+					"dev": "#adjacent-selectors"
+				},
+				"tests": "div > p"
+			},
+			"Attribute selectors": {
+				"links": {
+					"tr": "#attribute-selectors",
+					"dev": "#attribute-selectors"
+				},
+				"tests": [
+					"[title]", "[title=example]", "[title=\"example\"]", "[rel~=copyright]",
+					"[rel~=\"copyright\"]", "[lang|=en]", "[lang|=\"en\"]"
+				]
+			},
+			"ID selector": {
+				"links": {
+					"tr": "#id-selectors",
+					"dev": "#id-selectors"
+				},
+				"tests": "#id"
+			},
+			":first-child": {
+				"links": {
+					"tr": "#first-child",
+					"dev": "#first-child"
+				},
+				"tests": ":first-child"
+			},
+			":link": {
+				"links": {
+					"tr": "#link-pseudo-classes",
+					"dev": "#link-pseudo-classes"
+				},
+				"tests": ":link"
+			},
+			":visited": {
+				"links": {
+					"tr": "#link-pseudo-classes",
+					"dev": "#link-pseudo-classes"
+				},
+				"tests": ":visited"
+			},
+			":hover": {
+				"links": {
+					"tr": "#dynamic-pseudo-classes",
+					"dev": "#dynamic-pseudo-classes"
+				},
+				"tests": ":hover"
+			},
+			":active": {
+				"links": {
+					"tr": "#dynamic-pseudo-classes",
+					"dev": "#dynamic-pseudo-classes"
+				},
+				"tests": ":active"
+			},
+			":focus": {
+				"links": {
+					"tr": "#dynamic-pseudo-classes",
+					"dev": "#dynamic-pseudo-classes"
+				},
+				"tests": ":focus"
+			},
+			":lang()": {
+				"links": {
+					"tr": "#lang",
+					"dev": "#lang"
+				},
+				"tests": [":lang(en)", ":lang(en-US)"]
+			},
+			":first-line": {
+				"links": {
+					"tr": "#first-line-pseudo",
+					"dev": "#first-line-pseudo"
+				},
+				"tests": ":first-line"
+			},
+			":first-letter": {
+				"links": {
+					"tr": "#first-letter",
+					"dev": "#first-letter"
+				},
+				"tests": ":first-letter"
+			},
+			":before": {
+				"links": {
+					"tr": "#before-and-after",
+					"dev": "#before-and-after"
+				},
+				"tests": ":before"
+			},
+			":after": {
+				"links": {
+					"tr": "#before-and-after",
+					"dev": "#before-and-after"
+				},
+				"tests": ":after"
 			}
 		}
 	},
@@ -1541,7 +1751,7 @@ window.Specs = {
 					"tr": "#all-shorthand",
 					"dev": "#all-shorthand"
 				},
-				"tests": ["initial", "inherit", "unset"]
+				"tests": ["initial", "unset"]
 			}
 		}
 	},
@@ -4725,12 +4935,7 @@ window.Specs = {
 					"dev": "#at-page-rule"
 				},
 				"tests": [
-					"@page { margin: 2cm }",
-					"@page customName { margin: 2cm }",
-					"@page :left { margin: 2cm }",
-					"@page :right { margin: 2cm }",
-					"@page :first { margin: 2cm }",
-					"@page :blank { margin: 2cm }"
+					"@page customName { margin: 2cm; }"
 				]
 			}
 		},

--- a/tests.js
+++ b/tests.js
@@ -587,6 +587,22 @@ window.Specs = {
 				},
 				"tests": ["none", "\"»\" \"«\"", "'\"' '\"' \"'\" \"'\""]
 			}
+		},
+		"selectors": {
+			":before": {
+				"links": {
+					"tr": "#before-after-content",
+					"dev": "#before-after-content"
+				},
+				"tests": ":before"
+			},
+			":after": {
+				"links": {
+					"tr": "#before-after-content",
+					"dev": "#before-after-content"
+				},
+				"tests": ":after"
+			}
 		}
 	},
 
@@ -609,7 +625,10 @@ window.Specs = {
 					"dev": "#at-media-rule"
 				},
 				"tests": [
-					"@media print { color: green; }", "@media print, screen { color: green; }"
+					"@media all {\n  p {\n    color: green;\n  }\n}",
+					"@media print {\n  p {\n    color: green;\n  }\n}",
+					"@media screen {\n  p {\n    color: green;\n  }\n}",
+					"@media print, screen {\n  p {\n    color: green;\n  }\n}"
 				]
 			}
 		}
@@ -634,10 +653,13 @@ window.Specs = {
 				},
 				"tests": [
 					"@page { margin: 2cm; }",
+					"@page { margin-top: 2cm; }",
+					"@page { margin-right: 2cm; }",
+					"@page { margin-bottom: 2cm; }",
+					"@page { margin-left: 2cm; }",
 					"@page :left { margin: 2cm; }",
 					"@page :right { margin: 2cm; }",
-					"@page :first { margin: 2cm; }",
-					"@page :blank { margin: 2cm; }"
+					"@page :first { margin: 2cm; }"
 				]
 			}
 		},
@@ -683,7 +705,7 @@ window.Specs = {
 	"css2-selectors": {
 		"title": "CSS 2 Selectors",
 		"links": {
-			"tr": "CSS22/selectors.html",
+			"tr": "CSS22/selector.html",
 			"dev": "css2/"
 		},
 		"status": {
@@ -725,7 +747,7 @@ window.Specs = {
 					"tr": "#adjacent-selectors",
 					"dev": "#adjacent-selectors"
 				},
-				"tests": "div > p"
+				"tests": "div + p"
 			},
 			"Attribute selectors": {
 				"links": {
@@ -735,6 +757,15 @@ window.Specs = {
 				"tests": [
 					"[title]", "[title=example]", "[title=\"example\"]", "[rel~=copyright]",
 					"[rel~=\"copyright\"]", "[lang|=en]", "[lang|=\"en\"]"
+				]
+			},
+			"Class selector": {
+				"links": {
+					"tr": "#class-html",
+					"dev": "#class-html"
+				},
+				"tests": [
+					".class"
 				]
 			},
 			"ID selector": {
@@ -806,20 +837,6 @@ window.Specs = {
 					"dev": "#first-letter"
 				},
 				"tests": ":first-letter"
-			},
-			":before": {
-				"links": {
-					"tr": "#before-and-after",
-					"dev": "#before-and-after"
-				},
-				"tests": ":before"
-			},
-			":after": {
-				"links": {
-					"tr": "#before-and-after",
-					"dev": "#before-and-after"
-				},
-				"tests": ":after"
 			}
 		}
 	},
@@ -4935,6 +4952,7 @@ window.Specs = {
 					"dev": "#at-page-rule"
 				},
 				"tests": [
+					"@page :blank { margin: 2cm; }",
 					"@page customName { margin: 2cm; }"
 				]
 			}


### PR DESCRIPTION
This change adds the rest of the CSS 2 features except for `@import` and `!important`.

Testing for `@import` fails in Firefox because it waits until the external stylesheet is imported to assign `style.sheet`.
Testing for `!important` fails because the way property values are tested doesn't recognized that it's set.

This is in addition to #208.

Sebastian