### PR TITLE
Improve test coverage for media queries

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -395,13 +395,7 @@ Test.groups = {
 	},
 
 	'Media queries': function (test) {
-		var matches = matchMedia(test);
-		if (matches.media !== 'invalid' && matches.matches) {
-			return { success: true };
-		} else {
-			var matches = matchMedia('not ' + test);
-			return { success: matches.media !== 'invalid' && matches.matches };
-		}
+		return Supports.mq(test);
 	},
 };
 

--- a/supports.js
+++ b/supports.js
@@ -1,30 +1,3 @@
-/*! matchMedia() polyfill - Test a CSS media type/query in JS.
-Authors & copyright (c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas. Dual MIT/BSD license */
-window.matchMedia =
-	window.matchMedia ||
-	(function (doc, undefined) {
-		var bool,
-			docElem = doc.documentElement,
-			refNode = docElem.firstElementChild || docElem.firstChild,
-			// fakeBody required for <FF4 when executed in <head>
-			fakeBody = doc.createElement('body'),
-			div = doc.createElement('div');
-
-		div.id = 'mq-test-1';
-		div.style.cssText = 'position:absolute;top:-100em';
-		fakeBody.appendChild(div);
-
-		return function (q) {
-			div.innerHTML = '&shy;<style media="' + q + '"> #mq-test-1 { width: 42px; }</style>';
-
-			docElem.insertBefore(fakeBody, refNode);
-			bool = div.offsetWidth == 42;
-			docElem.removeChild(fakeBody);
-
-			return { matches: bool, media: q };
-		};
-	})(document);
-
 (function () {
 	/**
 	 * Setup dummy elements
@@ -208,25 +181,12 @@ window.matchMedia =
 		},
 
 		mq: function (mq) {
-			if (window.matchMedia) {
-				return {
-					success: matchMedia(mq).media !== 'invalid' ? true : matchMedia('not ' + mq).media !== 'invalid',
-				};
-			} else {
-				style.textContent = '@media ' + mq + '{ foo {} }';
-
-				if (style.sheet.cssRules.length > 0) {
-					return {
-						success: true,
-					};
-				} else {
-					style.textContent = '@media not ' + mq + '{ foo {} }';
-
-					return {
-						success: style.sheet.cssRules.length > 0 ? mq : false,
-					};
-				}
-			}
+			return {
+				// We check whether the query does not include 'not all' because
+				// if it does, that means the query is ignored.
+				// See https://drafts.csswg.org/cssom/#parse-a-media-query-list
+				success: !matchMedia(mq).media.includes('not all'),
+			};
 		},
 
 		variable: function (name, value) {

--- a/tests/css2-media.js
+++ b/tests/css2-media.js
@@ -9,18 +9,13 @@ export default {
 		'first-snapshot': 1998,
 		'last-snapshot': 1998,
 	},
-	'@rules': {
-		'@media': {
+	'Media queries': {
+		Syntax: {
 			links: {
 				tr: '#at-media-rule',
 				dev: '#at-media-rule',
 			},
-			tests: [
-				'@media all {\n  p {\n    color: green;\n  }\n}',
-				'@media print {\n  p {\n    color: green;\n  }\n}',
-				'@media screen {\n  p {\n    color: green;\n  }\n}',
-				'@media print, screen {\n  p {\n    color: green;\n  }\n}',
-			],
+			tests: ['all', 'print', 'screen', 'print, screen'],
 		},
 	},
 };

--- a/tests/mediaqueries-3.js
+++ b/tests/mediaqueries-3.js
@@ -1,6 +1,3 @@
-/*
- * Note: the following media queries must be true in supporting UAs!
- */
 export default {
 	title: 'Media Queries Level 3',
 	links: {
@@ -12,13 +9,20 @@ export default {
 		'first-snapshot': 2010,
 	},
 	'Media queries': {
-		negation: {
+		Syntax: {
 			links: {
-				tr: '#media0',
-				dev: '#media0',
-				mdn: 'Media_Queries/Using_media_queries',
+				tr: '#syntax',
+				dev: '#syntax',
 			},
-			tests: ['not print', 'not all and (width:1px)'],
+			tests: [
+				'not print',
+				'only screen',
+				'(width)',
+				'screen and (width)',
+				'not print and (width)',
+				'only screen and (width)',
+				'(width) and (height)',
+			],
 		},
 		width: {
 			links: {
@@ -26,7 +30,7 @@ export default {
 				dev: '#width',
 				mdn: 'Media_Queries/Using_media_queries',
 			},
-			tests: ['(width)', '(min-width:1px)', '(max-width:1000000px)'],
+			tests: ['(width)', '(width:1280px)', '(min-width:1px)', '(max-width:1000000px)'],
 		},
 		height: {
 			links: {
@@ -34,28 +38,38 @@ export default {
 				dev: '#height',
 				mdn: 'Media_Queries/Using_media_queries',
 			},
-			tests: ['(height)', '(min-height:1px)', '(max-height:1000000px)'],
+			tests: ['(height)', '(height:720px)', '(min-height:1px)', '(max-height:1000000px)'],
 		},
 		'device-width': {
 			links: {
 				tr: '#device-width',
 				dev: '#device-width',
 			},
-			tests: ['(device-width)', '(min-device-width:1px)', '(max-device-width:1000000px)'],
+			tests: [
+				'(device-width)',
+				'(device-width:1280px)',
+				'(min-device-width:1px)',
+				'(max-device-width:1000000px)',
+			],
 		},
 		'device-height': {
 			links: {
 				tr: '#device-height',
 				dev: '#device-height',
 			},
-			tests: ['(device-height)', '(min-device-height:1px)', '(max-device-height:1000000px)'],
+			tests: [
+				'(device-height)',
+				'(device-height:720px)',
+				'(min-device-height:1px)',
+				'(max-device-height:1000000px)',
+			],
 		},
 		orientation: {
 			links: {
 				tr: '#orientation',
 				dev: '#orientation',
 			},
-			tests: ['(orientation:portrait)', '(orientation:landscape)'],
+			tests: ['(orientation)', '(orientation:portrait)', '(orientation:landscape)'],
 		},
 		'aspect-ratio': {
 			links: {
@@ -64,8 +78,9 @@ export default {
 			},
 			tests: [
 				'(aspect-ratio)',
+				'(aspect-ratio:16/9)',
+				'(aspect-ratio:16 / 9)',
 				'(min-aspect-ratio:1/1000000)',
-				'(min-aspect-ratio:1 / 1000000)',
 				'(max-aspect-ratio:1000000/1)',
 			],
 		},
@@ -76,8 +91,9 @@ export default {
 			},
 			tests: [
 				'(device-aspect-ratio)',
+				'(device-aspect-ratio:16/9)',
+				'(device-aspect-ratio:16 / 9)',
 				'(min-device-aspect-ratio:1/1000000)',
-				'(min-device-aspect-ratio:1 / 1000000)',
 				'(max-device-aspect-ratio:1000000/1)',
 			],
 		},
@@ -86,21 +102,21 @@ export default {
 				tr: '#color',
 				dev: '#color',
 			},
-			tests: ['(color)', '(min-color: 0)', '(max-color: 100)'],
+			tests: ['(color)', '(color: 8)', '(min-color: 0)', '(max-color: 1000000)'],
 		},
 		'color-index': {
 			links: {
 				tr: '#color-index',
 				dev: '#color-index',
 			},
-			tests: ['all, (color-index)', '(min-color-index: 0)', '(max-color-index: 10000000)'],
+			tests: ['(color-index)', '(color-index: 256)', '(min-color-index: 0)', '(max-color-index: 1000000)'],
 		},
 		monochrome: {
 			links: {
 				tr: '#monochrome',
 				dev: '#monochrome',
 			},
-			tests: ['all, (monochrome)', '(min-monochrome: 0)', '(max-monochrome: 10000)'],
+			tests: ['(monochrome)', '(monochrome: 8)', '(min-monochrome: 0)', '(max-monochrome: 1000000)'],
 		},
 		resolution: {
 			links: {
@@ -109,9 +125,10 @@ export default {
 			},
 			tests: [
 				'(resolution)',
+				'(resolution:96dpi)',
+				'(resolution:10dpcm)',
 				'(min-resolution: 1dpi)',
 				'(max-resolution: 1000000dpi)',
-				'(max-resolution: 1000000dpcm)',
 			],
 		},
 		scan: {
@@ -119,14 +136,14 @@ export default {
 				tr: '#scan',
 				dev: '#scan',
 			},
-			tests: ['not tv, (scan: progressive)', 'not tv, (scan: interlace)'],
+			tests: ['(scan)', '(scan: progressive)', '(scan: interlace)'],
 		},
 		grid: {
 			links: {
 				tr: '#grid',
 				dev: '#grid',
 			},
-			tests: ['all, (grid)', '(grid: 0), (grid: 1)'],
+			tests: ['(grid)', '(grid: 0)', '(grid: 1)'],
 		},
 	},
 };

--- a/tests/mediaqueries-4.js
+++ b/tests/mediaqueries-4.js
@@ -8,6 +8,35 @@ export default {
 		stability: 'stable',
 	},
 	'Media queries': {
+		Syntax: {
+			links: {
+				tr: '#mq-syntax',
+				dev: '#mq-syntax',
+			},
+			tests: [
+				'not (width)',
+				'(width) or (height)',
+				'(not (width))',
+				'((width) and (height))',
+				'((width) or (height))',
+				'all and not (width)',
+				'all and (not (width))',
+				'all and ((width) and (height))',
+				'all and ((width) or (height))',
+				'(width = 1280px)',
+				'(width < 1000000px)',
+				'(width <= 1000000px)',
+				'(width > 1px)',
+				'(width >= 1px)',
+				'(1280px = width)',
+				'(1px < width)',
+				'(1px <= width)',
+				'(1000000px > width)',
+				'(1000000px >= width)',
+				'(1px <= width < 1000000px)',
+				'(1000000px > width >= 1px)',
+			],
+		},
 		resolution: {
 			links: {
 				tr: '#resolution',
@@ -56,9 +85,9 @@ export default {
 				dev: '#mf-overflow-block',
 			},
 			tests: [
+				'(overflow-block)',
 				'(overflow-block: none)',
 				'(overflow-block: scroll)',
-				'(overflow-block: optional-paged)',
 				'(overflow-block: paged)',
 			],
 		},
@@ -67,7 +96,7 @@ export default {
 				tr: '#mf-overflow-inline',
 				dev: '#mf-overflow-inline',
 			},
-			tests: ['(overflow-inline: none)', '(overflow-inline: scroll)'],
+			tests: ['(overflow-inline)', '(overflow-inline: none)', '(overflow-inline: scroll)'],
 		},
 		'color-gamut': {
 			links: {

--- a/tests/mediaqueries-5.js
+++ b/tests/mediaqueries-5.js
@@ -14,6 +14,7 @@ export default {
 				dev: '#display-modes',
 			},
 			tests: [
+				'(display-mode)',
 				'(display-mode: fullscreen)',
 				'(display-mode: standalone)',
 				'(display-mode: minimal-ui)',
@@ -62,6 +63,13 @@ export default {
 			},
 			tests: ['(prefers-color-scheme)', '(prefers-color-scheme: light)', '(prefers-color-scheme: dark)'],
 		},
+		'prefers-reduced-data': {
+			links: {
+				tr: '#prefers-reduced-data',
+				dev: '#prefers-reduced-data',
+			},
+			tests: ['(prefers-reduced-data)', '(prefers-reduced-data: no-preference)', '(prefers-reduced-data: reduce)'],
+		},
 		scripting: {
 			links: {
 				tr: '#scripting',
@@ -84,7 +92,7 @@ export default {
 		'forced-colors': {
 			links: {
 				tr: '#forced-colors',
-				dev: '#prefers-contrast',
+				dev: '#forced-colors',
 			},
 			tests: ['(forced-colors)', '(forced-colors: none)', '(forced-colors: active)'],
 		},
@@ -100,21 +108,21 @@ export default {
 				tr: '#mf-horizontal-viewport-segments',
 				dev: '#mf-horizontal-viewport-segments',
 			},
-			tests: ['(horizontal-viewport-segments: 2)'],
+			tests: ['(horizontal-viewport-segments)', '(horizontal-viewport-segments: 2)'],
 		},
 		'vertical-viewport-segments': {
 			links: {
 				tr: '#mf-vertical-viewport-segments',
 				dev: '#mf-vertical-viewport-segments',
 			},
-			tests: ['(vertical-viewport-segments: 2)'],
+			tests: ['(vertical-viewport-segments)', '(vertical-viewport-segments: 2)'],
 		},
 		'inverted-colors': {
 			links: {
 				tr: '#inverted',
 				dev: '#inverted',
 			},
-			tests: ['(inverted-colors)', '(inverted-colors: none)', '(light-level: inverted)'],
+			tests: ['(inverted-colors)', '(inverted-colors: none)', '(inverted-colors: inverted)'],
 		},
 		'nav-controls': {
 			links: {


### PR DESCRIPTION
In cba6568fa52863517e012f8f2b0964ff0ec5189b, i accidently broke a test about the `(orientation)` media feature because i forgot about the following note in `media-queries-3.js`:
> Note: the following media queries must be true in supporting UAs!

Only counting media queries that are true as passing tests is a long-standing behavior, but I don't think it makes sense because not every media queries can be true at the same time so it's not possible for a browser to reach 100%. Also testing if the negation is true as it was done does not work either because it uses syntaxes like `not (width)` are currently only supported by Firefox.

So in this PR, I reverted the way support for media queries is detected to be more like: *does it parse or not?* Also nowadays, we don't need anymore a polyfill for `matchMedia` so i directly called the built-in function to see if the browser recognizes media queries by checking for `"not all"` in the media list.

I also fixed some tests and added more tests about the syntax introduced in MQ3 and MQ4.