### PR TITLE
https://github.com/LeaVerou/css3test/issues/230

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,13 +62,6 @@
 		<ul id="specsTested"></ul>
 		Want more tests? <a href="https://github.com/LeaVerou/css3test" target="_blank">Be my guest!</a>
 	</section>
-
-	<section>
-		<h1>Cheaters</h1>
-		<ul>
-			<li>WebKit claims to support CSS3 background-repeat, but it’s LYING</li>
-		</ul>
-	</section>
 </aside>
 
 <footer>


### PR DESCRIPTION
Remove the "Cheater" warning about WebKit's support for `background-repeat`, because it's not accurate.