### PR TITLE
Added DOM feature checks

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -234,6 +234,9 @@ Test.prototype = {
 					case 'SVG':
 						mdnLink += 'SVG/Attribute/';
 						break;
+					case 'DOM':
+						mdnLink += 'API/';
+						break;
 					default:
 						mdnLink += 'CSS/';
 						// add exception for Media Queries if no link define
@@ -385,6 +388,10 @@ Test.groups = {
 
 	'@rules': function (test) {
 		return Supports.atrule(test);
+	},
+
+	interfaces: function (value, name, tests) {
+		return Supports.attributeOrMethod(name, value, tests[name].required, tests[name].interface);
 	},
 
 	'Media queries': function (test) {

--- a/tests.js
+++ b/tests.js
@@ -34,6 +34,7 @@ import cssEasing2 from './tests/css-easing-2.js';
 import cssEnv1 from './tests/css-env-1.js';
 import cssExclusions1 from './tests/css-exclusions-1.js';
 import cssFlexbox1 from './tests/css-flexbox-1.js';
+import cssFontLoading3 from './tests/css-font-loading-3.js';
 import cssFonts3 from './tests/css-fonts-3.js';
 import cssFonts4 from './tests/css-fonts-4.js';
 import cssFonts5 from './tests/css-fonts-5.js';
@@ -55,6 +56,7 @@ import cssMulticol1 from './tests/css-multicol-1.js';
 import cssMulticol2 from './tests/css-multicol-2.js';
 import cssNamespaces3 from './tests/css-namespaces-3.js';
 import cssNav1 from './tests/css-nav-1.js';
+import cssNesting1 from './tests/css-nesting-1.js';
 import cssOverflow3 from './tests/css-overflow-3.js';
 import cssOverflow4 from './tests/css-overflow-4.js';
 import cssOverscroll1 from './tests/css-overscroll-1.js';
@@ -83,6 +85,7 @@ import cssTextDecor4 from './tests/css-text-decor-4.js';
 import cssTransforms1 from './tests/css-transforms-1.js';
 import cssTransforms2 from './tests/css-transforms-2.js';
 import cssTransitions1 from './tests/css-transitions-1.js';
+import cssTransitions2 from './tests/css-transitions-2.js';
 import cssUi3 from './tests/css-ui-3.js';
 import cssUi4 from './tests/css-ui-4.js';
 import cssValues3 from './tests/css-values-3.js';
@@ -106,6 +109,7 @@ import css2Ui from './tests/css2-ui.js';
 import css2VisuDet from './tests/css2-visudet.js';
 import css2VisuFx from './tests/css2-visufx.js';
 import css2VisuRen from './tests/css2-visuren.js';
+import cssom1 from './tests/cssom-1.js';
 import cssomView1 from './tests/cssom-view-1.js';
 import fillStroke3 from './tests/fill-stroke-3.js';
 import filterEffects1 from './tests/filter-effects-1.js';
@@ -119,6 +123,7 @@ import mediaQueries5 from './tests/mediaqueries-5.js';
 import motion1 from './tests/motion-1.js';
 import pointerEvents1 from './tests/pointerevents1.js';
 import pointerEvents3 from './tests/pointerevents3.js';
+import resizeObserver1 from './tests/resize-observer-1.js';
 import scrollAnimations1 from './tests/scroll-animations-1.js';
 import selectors3 from './tests/selectors-3.js';
 import selectors4 from './tests/selectors-4.js';
@@ -129,6 +134,8 @@ import svg2Painting from './tests/svg2-painting.js';
 import svg2Paths from './tests/svg2-paths.js';
 import svg2PServers from './tests/svg2-pservers.js';
 import svg2Text from './tests/svg2-text.js';
+import webAnimations1 from './tests/web-animations-1.js';
+import webAnimations2 from './tests/web-animations-2.js';
 import webVtt from './tests/webvtt.js';
 
 
@@ -182,6 +189,7 @@ export default {
 	'css-env-1': cssEnv1,
 	'css-exclusions-1': cssExclusions1,
 	'css-flexbox-1': cssFlexbox1,
+	'css-font-loading-3': cssFontLoading3,
 	'css-fonts-3': cssFonts3,
 	'css-fonts-4': cssFonts4,
 	'css-fonts-5': cssFonts5,
@@ -203,6 +211,7 @@ export default {
 	'css-multicol-2': cssMulticol2,
 	'css-namespaces-3': cssNamespaces3,
 	'css-nav-1': cssNav1,
+	'css-nesting-1': cssNesting1,
 	'css-overflow-3': cssOverflow3,
 	'css-overflow-4': cssOverflow4,
 	'css-overscroll-1': cssOverscroll1,
@@ -231,6 +240,7 @@ export default {
 	'css-transforms-1': cssTransforms1,
 	'css-transforms-2': cssTransforms2,
 	'css-transitions-1': cssTransitions1,
+	'css-transitions-2': cssTransitions2,
 	'css-ui-3': cssUi3,
 	'css-ui-4': cssUi4,
 	'css-values-3': cssValues3,
@@ -241,6 +251,7 @@ export default {
 	'css-will-change-1': cssWillChange1,
 	'css-writing-modes-3': cssWritingModes3,
 	'css-writing-modes-4': cssWritingModes4,
+	'cssom-1': cssom1,
 	'cssom-view-1': cssomView1,
 	'fill-stroke-3': fillStroke3,
 	'filter-effects-1': filterEffects1,
@@ -254,6 +265,7 @@ export default {
 	'motion-1': motion1,
 	'pointerevents-1': pointerEvents1,
 	'pointerevents-3': pointerEvents3,
+	'resize-observer-1': resizeObserver1,
 	'scroll-animations-1': scrollAnimations1,
 	'selectors-3': selectors3,
 	'selectors-4': selectors4,
@@ -264,5 +276,7 @@ export default {
 	'svg2-paths': svg2Paths,
 	'svg2-pServers': svg2PServers,
 	'svg2-text': svg2Text,
+	'web-animations-1': webAnimations1,
+	'web-animations-2': webAnimations2,
 	webvtt: webVtt,
 };

--- a/tests/css-animations-1.js
+++ b/tests/css-animations-1.js
@@ -96,4 +96,58 @@ export default {
 			],
 		},
 	},
+	interfaces: {
+		AnimationEvent: {
+			links: {
+				tr: '#interface-animationevent',
+				dev: '#interface-animationevent',
+				mdnGroup: 'DOM',
+			},
+			tests: ['AnimationEvent'],
+		},
+		CSSRule: {
+			links: {
+				tr: '#interface-cssrule',
+				dev: '#interface-cssrule',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'KEYFRAMES_RULE',
+				'KEYFRAME_RULE',
+			],
+			required: 'div { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSKeyframesRule: {
+			links: {
+				tr: '#interface-csskeyframesrule',
+				dev: '#interface-csskeyframesrule',
+				mdnGroup: 'DOM',
+			},
+			tests: ['name', 'cssRules', 'length', 'appendRule', 'deleteRule', 'findRule'],
+			required: '@keyframes foo { from {} to {} }',
+		},
+		CSSKeyframeRule: {
+			links: {
+				tr: '#interface-csskeyframerule',
+				dev: '#interface-csskeyframerule',
+				mdnGroup: 'DOM',
+			},
+			tests: ['keyText', 'style'],
+			required: '@keyframes foo { from {} to {} }',
+		},
+		Element: {
+			links: {
+				tr: '#interface-globaleventhandlers',
+				dev: '#interface-globaleventhandlers',
+				mdnGroup: 'DOM',
+			},
+			tests: ['onanimationstart', 'onanimationiteration', 'onanimationend', 'onanimationcancel'],
+			interface: function(style) {
+				return document.body;
+			},
+		}
+	},
 };

--- a/tests/css-animations-2.js
+++ b/tests/css-animations-2.js
@@ -60,4 +60,23 @@ export default {
 			tests: ['1s both infinite auto'],
 		},
 	},
+	interfaces: {
+		CSSAnimation: {
+			links: {
+				tr: '#the-CSSAnimation-interface',
+				dev: '#the-CSSAnimation-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['animationName'],
+			required: '@keyframes slide-in { 0% { transform: translateY(-1000px); } 100% { transform: translateY(0); } } .animate { animation: slide-in 0.7s both; }',
+			interface: function(style) {
+				var div = document.createElement('div');
+				div.className = 'animate';
+				body.append(div);
+				var animations = div.getAnimations && div.getAnimations();
+				div.remove();
+				return animations.length > 0 && animations[0];
+			}
+		},
+	},
 };

--- a/tests/css-cascade-5.js
+++ b/tests/css-cascade-5.js
@@ -40,4 +40,35 @@ export default {
 			],
 		},
 	},
+	interfaces: {
+		/* Doesn't currently work because style sheet is only available once imported
+		CSSImportRule: {
+			links: {
+				tr: '#extensions-to-cssimportrule-interface',
+				dev: '#extensions-to-cssimportrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['layerName'],
+			required: '@import url("foo.css") layer(mylayer);',
+		},
+		*/
+		CSSLayerBlockRule: {
+			links: {
+				tr: '#the-csslayerblockrule-interface',
+				dev: '#the-csslayerblockrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['name', 'cssRules', 'insertRule', 'deleteRule'],
+			required: '@layer mylayer { }',
+		},
+		CSSLayerStatementRule: {
+			links: {
+				tr: '#the-csslayerstatementrule-interface',
+				dev: '#the-csslayerstatementrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['nameList', 'cssText', 'parentRule', 'parentStyleSheet'],
+			required: '@layer firstLayer, secondLayer;',
+		},
+	},
 };

--- a/tests/css-cascade-6.js
+++ b/tests/css-cascade-6.js
@@ -28,4 +28,14 @@ export default {
 			tests: 'foo >> bar',
 		},
 	},
+	interfaces: {
+		CSSScopeRule: {
+			links: {
+				dev: '#the-cssscoperule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['start', 'end', 'cssRules', 'insertRule', 'deleteRule'],
+			required: '@scope (foo) to (bar) {}',
+		}
+	}
 }

--- a/tests/css-color-5.js
+++ b/tests/css-color-5.js
@@ -46,4 +46,14 @@ export default {
 			],
 		},
 	},
+	interfaces: {
+		CSSColorProfileRule: {
+			links: {
+				dev: '#the-csscolorprofilerule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['name', 'src', 'renderingIntent', 'components', 'cssText', 'parentRule', 'parentStyleSheet'],
+			required: '@color-profile { name: "sRGB"; src: url("sRGB.icc"); }',
+		},
+	}
 };

--- a/tests/css-conditional-3.js
+++ b/tests/css-conditional-3.js
@@ -24,4 +24,65 @@ export default {
 			],
 		},
 	},
+	interfaces: {
+		CSSRule: {
+			links: {
+				tr: '#extensions-to-cssrule-interface',
+				dev: '#extensions-to-cssrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['SUPPORTS_RULE'],
+			required: 'div { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSConditionRule: {
+			links: {
+				tr: '#the-cssconditionrule-interface',
+				dev: '#the-cssconditionrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['conditionText', 'cssRules', 'insertRule', 'deleteRule'],
+			required: '@supports (color: green) { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSMediaRule: {
+			links: {
+				tr: '#the-cssmediarule-interface',
+				dev: '#the-cssmediarule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['media', 'conditionText'],
+			required: '@media (min-width: 500px) { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSSupportsRule: {
+			links: {
+				tr: '#the-csssupportsrule-interface',
+				dev: '#the-csssupportsrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['conditionText'],
+			required: '@supports (display: grid) { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSS: {
+			links: {
+				tr: '#the-css-namespace',
+				dev: '#the-css-namespace',
+				mdnGroup: 'DOM',
+			},
+			tests: ['supports'],
+			interface: function() {
+				return CSS;
+			}
+		},
+	},
 };

--- a/tests/css-containment-2.js
+++ b/tests/css-containment-2.js
@@ -23,4 +23,13 @@ export default {
 			tests: ['visible', 'auto', 'hidden'],
 		},
 	},
+	interfaces: {
+		ContentVisibilityAutoStateChangeEvent: {
+			links: {
+				dev: '#content-visibility-auto-state-change',
+				mdnGroup: 'DOM',
+			},
+			tests: ['ContentVisibilityAutoStateChangeEvent'],
+		},
+	}
 };

--- a/tests/css-containment-3.js
+++ b/tests/css-containment-3.js
@@ -113,4 +113,18 @@ export default {
 			tests: ['none', 'style', 'x / size', 'x y / size', 'x / size style'],
 		},
 	},
+	interfaces: {
+		CSSContainerRule: {
+			links: {
+				tr: '#the-csscontainerrule-interface',
+				dev: '#the-csscontainerrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['containerName', 'containerQuery', 'conditionText'],
+			required: '@container (min-width: 500px) { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+	},
 };

--- a/tests/css-counter-styles-3.js
+++ b/tests/css-counter-styles-3.js
@@ -154,4 +154,45 @@ export default {
 			tests: ['auto', 'bullets', 'numbers', 'words', 'spell-out', 'example-counter'],
 		},
 	},
+	interfaces: {
+		CSSRule: {
+			links: {
+				tr: '#extensions-to-cssrule-interface',
+				dev: '#extensions-to-cssrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['COUNTER_STYLE_RULE'],
+			required: 'div { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSCounterStyleRule: {
+			links: {
+				tr: '#the-csscounterstylerule-interface',
+				dev: '#the-csscounterstylerule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'name',
+				'system',
+				'symbols',
+				'additiveSymbols',
+				'negative',
+				'prefix',
+				'suffix',
+				'range',
+				'pad',
+				'speakAs',
+				'fallback',
+				'cssText',
+				'parentRule',
+				'parentStyleSheet',
+			],
+			required: '@counter-style example { system: alphabetic; symbols: A B C D; additive-symbols: 1000 M, 500 C; }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+	},
 };

--- a/tests/css-font-loading-3.js
+++ b/tests/css-font-loading-3.js
@@ -1,0 +1,119 @@
+export default {
+	title: 'CSS Font Loading Module Level 3',
+	links: {
+		tr: 'css-font-loading-3',
+		dev: 'css-font-loading-3',
+	},
+	status: {
+		stability: 'stable',
+	},
+	interfaces: {
+		FontFace: {
+			links: {
+				tr: '#fontface-interface',
+				dev: '#fontface-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'family',
+				'style',
+				'weight',
+				'stretch',
+				'unicodeRange',
+				'variant',
+				'featureSettings',
+				'variationSettings',
+				'display',
+				'ascenderOverride',
+				'descenderOverride',
+				'lineGapOverride',
+				'status',
+				'load',
+				'loaded',
+				'features',
+				'variations',
+				'palettes',
+			],
+			interface: function() {
+				return new FontFace('test', 'url("test.woff")');
+			},
+		},
+		FontFaceFeatures: {
+			links: {
+				dev: '#fontfacefeatures',
+				mdnGroup: 'DOM',
+			},
+			tests: ['FontFaceFeatures'],
+			interface: function() {
+				return new FontFace('test', 'url("test.woff")').features;
+			},
+		},
+		FontFaceVariationAxis: {
+			links: {
+				dev: '#fontfacevariationaxis',
+				mdnGroup: 'DOM',
+			},
+			tests: ['name', 'axisTag', 'minimumValue', 'maximumValue', 'defaultValue'],
+			interface: function() {
+				return new FontFace('test', 'url("test.woff")').variations;
+			},
+		},
+		FontFacePalettes: {
+			links: {
+				dev: '#fontfacepalettes',
+				mdnGroup: 'DOM',
+			},
+			tests: ['length'],
+			interface: function() {
+				return new FontFace('test', 'url("test.woff")').palettes;
+			},
+		},
+		FontFacePalette: {
+			links: {
+				dev: '#fontfacepalette',
+				mdnGroup: 'DOM',
+			},
+			tests: ['FontFacePalette'],
+		},
+		FontFaceSet: {
+			links: {
+				tr: '#FontFaceSet-interface',
+				dev: '#FontFaceSet-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'add',
+				'delete',
+				'clear',
+				'onloading',
+				'onloadingdone',
+				'onloadingerror',
+				'load',
+				'check',
+				'ready',
+				'status',
+			],
+			interface: function() {
+				return document.fonts;
+			}
+		},
+		FontFaceSetLoadEvent: {
+			links: {
+				dev: '#fontfacesetloadevent',
+				mdnGroup: 'DOM',
+			},
+			tests: ['FontFaceSetLoadEvent'],
+		},
+		Document: {
+			links: {
+				tr: '#font-face-source',
+				dev: '#font-face-source',
+				mdnGroup: 'DOM',
+			},
+			tests: ['fonts'],
+			interface: function() {
+				return document;
+			},
+		}
+	},
+};

--- a/tests/css-fonts-3.js
+++ b/tests/css-fonts-3.js
@@ -217,4 +217,15 @@ export default {
 			tests: "@font-face {\n  font-family: foo;\n  src: local('Arial');\n}",
 		},
 	},
+	interfaces: {
+		CSSFontFaceRule: {
+			links: {
+				tr: '#om-fontface',
+				dev: '#om-fontface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['style', 'cssText', 'parentRule', 'parentStyleSheet'],
+			required: '@font-face { font-family: "Foo"; src: local("Foo") }',
+		},
+	},
 };

--- a/tests/css-fonts-4.js
+++ b/tests/css-fonts-4.js
@@ -358,4 +358,84 @@ export default {
 			tests: ['auto', 'block', 'swap', 'fallback', 'optional'],
 		},
 	},
+	interfaces: {
+		CSSRule: {
+			links: {
+				tr: '#om-fontfeaturevalues',
+				dev: '#om-fontfeaturevalues',
+				mdnGroup: 'DOM',
+			},
+			tests: ['FONT_FEATURE_VALUES_RULE'],
+			required: 'div { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSFontFeatureValuesRule: {
+			links: {
+				tr: '#om-fontfeaturevalues',
+				dev: '#om-fontfeaturevalues',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'fontFamily',
+				'annotation',
+				'ornaments',
+				'stylistic',
+				'swash',
+				'characterVariant',
+				'styleset',
+				'cssText',
+				'parentRule',
+				'parentStyleSheet',
+			],
+			required: '@font-feature-values Font One { @styleset { nice-style: 12; } }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSFontFeatureValuesMap: {
+			links: {
+				tr: '#cssfontfeaturevaluesmap',
+				dev: '#cssfontfeaturevaluesmap',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'has',
+				'get',
+				'set',
+				'keys',
+				'values',
+				'entries',
+				'forEach',
+				'clear',
+				'delete',
+				'size',
+			],
+			required: '@font-feature-values Font One { @styleset { nice-style: 12; } }',
+			interface: function(style) {
+				return style.sheet.cssRules[0].styleset;
+			},
+		},
+		CSSFontPaletteValuesRule: {
+			links: {
+				tr: '#om-fontpalettevalues',
+				dev: '#om-fontpalettevalues',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'name',
+				'fontFamily',
+				'basePalette',
+				'overrideColors',
+				'cssText',
+				'parentRule',
+				'parentStyleSheet',
+			],
+			required: '@font-palette-values --identifier { font-family: foo; override-colors: 0 #00ffbb, 1 #007744; }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+	},
 };

--- a/tests/css-highlight-api-1.js
+++ b/tests/css-highlight-api-1.js
@@ -16,4 +16,42 @@ export default {
 			tests: ['::highlight(example-highlight)'],
 		},
 	},
+	interfaces: {
+		CSS: {
+			links: {
+				tr: '#registration',
+				dev: '#registration',
+				mdnGroup: 'DOM',
+			},
+			tests: ['highlights'],
+			interface: function() {
+				return CSS;
+			}
+		},
+		Highlight: {
+			links: {
+				tr: '#creation',
+				dev: '#creation',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'priority',
+				'type',
+				'has',
+				'add',
+				'delete',
+				'clear',
+				'values',
+				'keys',
+				'entries',
+				'forEach',
+			],
+			interface: function(style) {
+				var range = new Range();
+				range.setStart(document.body, 10);
+				range.setEnd(document.body, 20);
+				return new Highlight(range);
+			}
+		},
+	}
 };

--- a/tests/css-images-4.js
+++ b/tests/css-images-4.js
@@ -117,4 +117,17 @@ export default {
 			],
 		},
 	},
+	interfaces: {
+		CSS: {
+			links: {
+				tr: '#elementsources',
+				dev: '#elementsources',
+				mdnGroup: 'DOM',
+			},
+			tests: ['elementSources'],
+			interface: function() {
+				return CSS;
+			}
+		},
+	},
 };

--- a/tests/css-nav-1.js
+++ b/tests/css-nav-1.js
@@ -30,4 +30,36 @@ export default {
 			tests: ['normal', 'grid'],
 		},
 	},
+	interfaces: {
+		Window: {
+			links: {
+				tr: '#high-level-api',
+				dev: '#high-level-api',
+				mdnGroup: 'DOM',
+			},
+			tests: ['navigate'],
+			interface: function() {
+				return window;
+			}
+		},
+		Element: {
+			links: {
+				tr: '#low-level-api',
+				dev: '#low-level-api',
+				mdnGroup: 'DOM',
+			},
+			tests: ['getSpatialNavigationContainer', 'focusableAreas', 'spatialNavigationSearch'],
+			interface: function() {
+				return document.body;
+			}
+		},
+		NavigationEvent: {
+			links: {
+				tr: '#events-navigationevent',
+				dev: '#events-navigationevent',
+				mdnGroup: 'DOM',
+			},
+			tests: ['NavigationEvent'],
+		},
+	},
 };

--- a/tests/css-nesting-1.js
+++ b/tests/css-nesting-1.js
@@ -1,0 +1,21 @@
+export default {
+	title: 'CSS Nesting Module',
+	links: {
+		tr: 'css-nesting-1',
+		dev: 'css-nesting-1',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	interfaces: {
+		CSSStyleRule: {
+			links: {
+				tr: '#cssom-style',
+				dev: '#cssom-style',
+				mdnGroup: 'DOM',
+			},
+			tests: ['cssRules', 'insertRule', 'deleteRule'],
+			required: 'div { }',
+		},
+	},
+};

--- a/tests/css-pseudo-4.js
+++ b/tests/css-pseudo-4.js
@@ -58,4 +58,28 @@ export default {
 			tests: ['::placeholder'],
 		},
 	},
+	interfaces: {
+		Element: {
+			links: {
+				tr: '#window-interface',
+				dev: '#window-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['pseudo'],
+			interface: function() {
+				return document.body;
+			},
+		},
+		CSSPseudoElement: {
+			links: {
+				tr: '#CSSPseudoElement-interface',
+				dev: '#CSSPseudoElement-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['type', 'element', 'parent', 'pseudo'],
+			interface: function() {
+				return document.body.pseudo('::selection');
+			},
+		},
+	},
 };

--- a/tests/css-regions-1.js
+++ b/tests/css-regions-1.js
@@ -30,4 +30,64 @@ export default {
 			tests: ['auto', 'break'],
 		},
 	},
+	interfaces: {
+		Document: {
+			links: {
+				tr: '#the-namedflow-interface',
+				dev: '#the-namedflow-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['namedFlows'],
+			interface: function() {
+				return document;
+			}
+		},
+		Element: {
+			links: {
+				tr: '#the-region-interface',
+				dev: '#the-region-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['regionOverset', 'getRegionFlowRanges'],
+			interface: function() {
+				return document.body;
+			}
+		},
+		NamedFlowMap: {
+			links: {
+				dev: '#namedflowmap',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'has',
+				'get',
+				'set',
+				'keys',
+				'values',
+				'entries',
+				'forEach',
+			],
+			interface: function() {
+				return document.namedFlows;
+			}
+		},
+		NamedFlow: {
+			links: {
+				dev: '#namedflow',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'name',
+				'overset',
+				'getRegions',
+				'firstEmptyRegionIndex',
+				'getContent',
+				'getRegionsByContent',
+			],
+			required: 'div { flow-from: --named-flow; }',
+			interface: function() {
+				return document.namedFlows.get('--named-flow');
+			}
+		},
+	},
 };

--- a/tests/css-shadow-parts-1.js
+++ b/tests/css-shadow-parts-1.js
@@ -16,4 +16,17 @@ export default {
 			tests: ['::part(label)'],
 		},
 	},
+	interfaces: {
+		Element: {
+			links: {
+				tr: '#idl',
+				dev: '#idl',
+				mdnGroup: 'DOM',
+			},
+			tests: ['part'],
+			interface: function() {
+				return document.body;
+			},
+		},
+	},
 };

--- a/tests/css-transitions-1.js
+++ b/tests/css-transitions-1.js
@@ -56,4 +56,25 @@ export default {
 			tests: '1s 2s width linear',
 		},
 	},
+	interfaces: {
+		TransitionEvent: {
+			links: {
+				tr: '#interface-transitionevent',
+				dev: '#interface-transitionevent',
+				mdnGroup: 'DOM',
+			},
+			tests: ['TransitionEvent'],
+		},
+		Element: {
+			links: {
+				tr: '#interface-dom',
+				dev: '#interface-dom',
+				mdnGroup: 'DOM',
+			},
+			tests: ['ontransitionstart', 'ontransitionrun', 'ontransitionend', 'ontransitioncancel'],
+			interface: function() {
+				return document.body;
+			},
+		},
+	},
 };

--- a/tests/css-transitions-2.js
+++ b/tests/css-transitions-2.js
@@ -1,0 +1,51 @@
+export default {
+	title: 'CSS Transitions 2',
+	links: {
+		dev: 'css-transitions-2',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	interfaces: {
+		CSSTransition: {
+			links: {
+				dev: '#the-CSSTransition-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'transitionProperty',
+				'id',
+				'effect',
+				'timeline',
+				'startTime',
+				'currentTime',
+				'playbackRate',
+				'playState',
+				'replaceState',
+				'pending',
+				'ready',
+				'finished',
+				'onfinish',
+				'oncancel',
+				'onremove',
+				'cancel',
+				'finish',
+				'play',
+				'pause',
+				'updatePlaybackRate',
+				'reverse',
+				'persist',
+				'commitStyles',
+			],
+			interface: function() {
+				var div = document.createElement('div');
+				document.body.append(div);
+				div.style.transition = 'opacity 100s';
+				div.style.opacity = '0';
+				getComputedStyle(div).opacity;
+				div.style.opacity = '1';
+				return div.getAnimations()[0];
+			}
+		},
+	},
+};

--- a/tests/css-view-transitions-1.js
+++ b/tests/css-view-transitions-1.js
@@ -65,4 +65,28 @@ export default {
 			],
 		},
 	},
+	interfaces: {
+		Document: {
+			links: {
+				tr: '#additions-to-document-api',
+				dev: '#additions-to-document-api',
+				mdnGroup: 'DOM',
+			},
+			tests: ['startViewTransition'],
+			interface: function() {
+				return document;
+			},
+		},
+		ViewTransition: {
+			links: {
+				tr: '#the-domtransition-interface',
+				dev: '#the-domtransition-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['updateCallbackDone', 'ready', 'finished', 'skipTransition'],
+			interface: function() {
+				return document.startViewTransition();
+			},
+		},
+	},
 };

--- a/tests/cssom-1.js
+++ b/tests/cssom-1.js
@@ -1,0 +1,251 @@
+export default {
+	title: 'CSS Object Model (CSSOM)',
+	links: {
+		tr: 'cssom-1',
+		dev: 'cssom-1',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	interfaces: {
+		CSS: {
+			links: {
+				tr: '#namespacedef-css',
+				dev: '#namespacedef-css',
+				mdnGroup: 'DOM',
+			},
+			tests: ['escape'],
+			interface: function() {
+				return CSS;
+			}
+		},
+		StyleSheet: {
+			links: {
+				tr: '#the-stylesheet-interface',
+				dev: '#the-stylesheet-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'type',
+				'href',
+				'ownerNode',
+				'parentStyleSheet',
+				'title',
+				'media',
+				'disabled',
+			],
+			interface: function(style) {
+				return style.sheet;
+			}
+		},
+		CSSStyleSheet: {
+			links: {
+				tr: '#the-cssstylesheet-interface',
+				dev: '#the-cssstylesheet-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'type',
+				'href',
+				'title',
+				'media',
+				'ownerNode',
+				'parentStyleSheet',
+				'title',
+				'media',
+				'disabled',
+				'ownerRule',
+				'cssRules',
+				'insertRule',
+				'deleteRule',
+				'rules',
+				'addRule',
+				'removeRule',
+				'replace',
+				'replaceSync',
+			],
+			interface: function(style) {
+				return style.sheet;
+			}
+		},
+		StyleSheetList: {
+			links: {
+				tr: '#the-stylesheetlist-interface',
+				dev: '#the-stylesheetlist-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['item', 'length'],
+			interface: function() {
+				return document.styleSheets;
+			}
+		},
+		Document: {
+			links: {
+				tr: '#extensions-to-the-document-or-shadow-root-interface',
+				dev: '#extensions-to-the-document-or-shadow-root-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['styleSheets', 'adoptedStyleSheets'],
+			interface: function() {
+				return document;
+			},
+		},
+		Element: {
+			links: {
+				tr: '#the-linkstyle-interface',
+				dev: '#the-linkstyle-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['sheet', 'style'],
+			interface: function(style) {
+				return style;
+			},
+		},
+		Window: {
+			links: {
+				tr: '#extensions-to-the-window-interface',
+				dev: '#extensions-to-the-window-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['getComputedStyle'],
+			interface: function() {
+				return window;
+			},
+		},
+		MediaList: {
+			links: {
+				tr: '#the-medialist-interface',
+				dev: '#the-medialist-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['mediaText', 'length', 'item', 'appendMedium', 'deleteMedium'],
+			interface: function(style) {
+				return style.sheet.media;
+			}
+		},
+		CSSRuleList: {
+			links: {
+				tr: '#the-cssrulelist-interface',
+				dev: '#the-cssrulelist-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['item', 'length'],
+			interface: function(style) {
+				return style.sheet.cssRules;
+			}
+		},
+		CSSRule: {
+			links: {
+				tr: '#the-cssrule-interface',
+				dev: '#the-cssrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'cssText',
+				'parentRule',
+				'parentStyleSheet',
+				'type',
+				'STYLE_RULE',
+				'CHARSET_RULE',
+				'IMPORT_RULE',
+				'MEDIA_RULE',
+				'FONT_FACE_RULE',
+				'PAGE_RULE',
+				'MARGIN_RULE',
+				'NAMESPACE_RULE',
+			],
+			required: 'div { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			}
+		},
+		CSSStyleRule: {
+			links: {
+				tr: '#the-cssstylerule-interface',
+				dev: '#the-cssstylerule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['selectorText', 'style', 'cssText', 'parentRule', 'parentStyleSheet'],
+			required: 'div { }',
+		},
+		/* Doesn't currently work because style sheet is only available once imported
+		CSSImportRule: {
+			links: {
+				tr: '#the-cssimportrule-interface',
+				dev: '#the-cssimportrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['href', 'media', 'styleSheet'],
+			required: '@import url("foo.css");',
+		},
+		*/
+		CSSGroupingRule: {
+			links: {
+				tr: '#the-cssgroupingrule-interface',
+				dev: '#the-cssgroupingrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'cssRules',
+				'insertRule',
+				'deleteRule',
+				'cssText',
+				'parentRule',
+				'parentStyleSheet',
+			],
+			required: '@media { }',
+			interface: function(style) {
+				return style.sheet.cssRules[0];
+			},
+		},
+		CSSPageRule: {
+			links: {
+				tr: '#the-csspagerule-interface',
+				dev: '#the-csspagerule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['selectorText', 'style', 'cssRules', 'insertRule', 'deleteRule'],
+			required: '@page { }',
+		},
+		CSSMarginRule: {
+			links: {
+				tr: '#the-cssmarginrule-interface',
+				dev: '#the-cssmarginrule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['selectorText', 'style', 'cssText', 'parentRule', 'parentStyleSheet'],
+			required: '@page { @top-left { content: "foo"; } }',
+		},
+		CSSNamespaceRule: {
+			links: {
+				tr: '#the-cssnamespacerule-interface',
+				dev: '#the-cssnamespacerule-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['namespaceURI', 'prefix', 'cssText', 'parentRule', 'parentStyleSheet'],
+			required: '@namespace svg url("http://www.w3.org/2000/svg");',
+		},
+		CSSStyleDeclaration: {
+			links: {
+				tr: '#the-cssstyledeclaration-interface',
+				dev: '#the-cssstyledeclaration-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'cssText',
+				'length',
+				'item',
+				'getPropertyValue',
+				'getPropertyPriority',
+				'setProperty',
+				'removeProperty',
+				'parentRule',
+				'cssFloat'
+			],
+			required: 'div { color: red; }',
+			interface: function(style) {
+				return style.sheet.cssRules[0].style;
+			}
+		},
+	},
+};

--- a/tests/cssom-view-1.js
+++ b/tests/cssom-view-1.js
@@ -16,4 +16,260 @@ export default {
 			tests: ['auto', 'smooth '],
 		},
 	},
+	interfaces: {
+		Window: {
+			links: {
+				tr: '#extensions-to-the-window-interface',
+				dev: '#extensions-to-the-window-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'matchMedia',
+				'screen',
+				'visualViewport',
+				'moveTo',
+				'moveBy',
+				'resizeTo',
+				'resizeBy',
+				'innerWidth',
+				'innerHeight',
+				'scrollX',
+				'pageXOffset',
+				'scrollY',
+				'pageYOffset',
+				'scroll',
+				'scrollTo',
+				'scrollBy',
+				'screenX',
+				'screenLeft',
+				'screenY',
+				'screenTop',
+				'outerWidth',
+				'outerHeight',
+				'devicePixelRatio',
+			],
+			interface: function() {
+				return window;
+			},
+		},
+		MediaQueryList: {
+			links: {
+				tr: '#the-mediaquerylist-interface',
+				dev: '#the-mediaquerylist-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['media', 'matches', 'addListener', 'removeListener', 'onchange'],
+			interface: function() {
+				return window.matchMedia('');
+			},
+		},
+		MediaQueryListEvent: {
+			links: {
+				tr: '#mediaquerylistevent',
+				dev: '#mediaquerylistevent',
+				mdnGroup: 'DOM',
+			},
+			tests: ['matches'],
+			interface: function() {
+				return new MediaQueryListEvent('change', {matches: true});
+			},
+		},
+		Screen: {
+			links: {
+				tr: '#the-screen-interface',
+				dev: '#the-screen-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'availWidth',
+				'availHeight',
+				'width',
+				'height',
+				'colorDepth',
+				'pixelDepth',
+			],
+			interface: function() {
+				return window.screen;
+			},
+		},
+		Document: {
+			links: {
+				tr: '#extensions-to-the-document-interface',
+				dev: '#extensions-to-the-document-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'elementFromPoint',
+				'elementsFromPoint',
+				'caretPositionFromPoint',
+				'scrollingElement',
+				'getBoxQuads',
+				'convertQuadFromNode',
+				'convertRectFromNode',
+				'convertPointFromNode',
+			],
+			interface: function() {
+				return document;
+			},
+		},
+		CaretPosition: {
+			links: {
+				tr: '#caretposition',
+				dev: '#caretposition',
+				mdnGroup: 'DOM',
+			},
+			tests: ['offsetNode', 'offset', 'getClientRect'],
+			interface: function() {
+				return document.caretPositionFromPoint(0, 0);
+			},
+		},
+		Element: {
+			links: {
+				tr: '#extension-to-the-element-interface',
+				dev: '#extension-to-the-element-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'getClientRects',
+				'getBoundingClientRect',
+				'checkVisibility',
+				'scrollIntoView',
+				'scroll',
+				'scrollTo',
+				'scrollBy',
+				'scrollTop',
+				'scrollLeft',
+				'scrollWidth',
+				'scrollHeight',
+				'clientTop',
+				'clientLeft',
+				'clientWidth',
+				'clientHeight',
+				'getBoxQuads',
+				'convertQuadFromNode',
+				'convertRectFromNode',
+				'convertPointFromNode',
+			],
+			interface: function() {
+				return document.createElement('div');
+			},
+		},
+		HTMLElement: {
+			links: {
+				tr: '#extensions-to-the-htmlelement-interface',
+				dev: '#extensions-to-the-htmlelement-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'offsetParent',
+				'offsetTop',
+				'offsetLeft',
+				'offsetWidth',
+				'offsetHeight',
+			],
+			interface: function() {
+				return document.createElement('div');
+			},
+		},
+		HTMLImageElement: {
+			links: {
+				tr: '#extensions-to-the-htmlimageelement-interface',
+				dev: '#extensions-to-the-htmlimageelement-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['x', 'y'],
+			interface: function() {
+				return document.createElement('img');
+			},
+		},
+		Range: {
+			links: {
+				tr: '#extensions-to-the-range-interface',
+				dev: '#extensions-to-the-range-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['getClientRects', 'getBoundingClientRect'],
+			interface: function() {
+				return document.createRange();
+			},
+		},
+		MouseEvent: {
+			links: {
+				tr: '#extensions-to-the-mouseevent-interface',
+				dev: '#extensions-to-the-mouseevent-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'screenX',
+				'screenY',
+				'pageX',
+				'pageY',
+				'clientX',
+				'clientY',
+				'x',
+				'y',
+				'offsetX',
+				'offsetY',
+			],
+			interface: function() {
+				return new MouseEvent('click', {screenX: 0, screenY: 0, clientX: 0, clientY: 0});
+			},
+		},
+		Text: {
+			links: {
+				tr: '#geometryutils',
+				dev: '#geometryutils',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'getBoxQuads',
+				'convertQuadFromNode',
+				'convertRectFromNode',
+				'convertPointFromNode',
+			],
+			interface: function() {
+				return document.createTextNode('');
+			},
+		},
+		CSSPseudoElement: {
+			links: {
+				tr: '#geometryutils',
+				dev: '#geometryutils',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'getBoxQuads',
+				'convertQuadFromNode',
+				'convertRectFromNode',
+				'convertPointFromNode',
+			],
+			interface: function() {
+				return document.createTextNode('');
+			},
+		},
+		VisualViewport: {
+			links: {
+				dev: '#the-visualviewport-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'offsetLeft',
+				'offsetTop',
+				'pageLeft',
+				'pageTop',
+				'width',
+				'height',
+				'scale',
+				'onresize',
+				'onscroll',
+				'onscrollend',
+				'addEventListener',
+				'removeEventListener',
+				'dispatchEvent',
+			],
+			interface: function() {
+				return window.visualViewport;
+			},
+		},
+	},
 };

--- a/tests/resize-observer-1.js
+++ b/tests/resize-observer-1.js
@@ -1,0 +1,39 @@
+export default {
+	title: 'Resize Observer',
+	links: {
+		tr: 'resize-observer-1',
+		dev: 'resize-observer-1',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	interfaces: {
+		ResizeObserver: {
+			links: {
+				tr: '#api',
+				dev: '#api',
+				mdnGroup: 'DOM',
+			},
+			tests: ['observe', 'unobserve', 'disconnect'],
+			interface: function() {
+				return new ResizeObserver(function() {});
+			}
+		},
+		ResizeObserverEntry: {
+			links: {
+				tr: '#resize-observer-entry-interface',
+				dev: '#resize-observer-entry-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['ResizeObserverEntry'],
+		},
+		ResizeObserverSize: {
+			links: {
+				tr: '#resizeobserversize',
+				dev: '#resizeobserversize',
+				mdnGroup: 'DOM',
+			},
+			tests: ['ResizeObserverEntry'],
+		},
+	},
+};

--- a/tests/scroll-animations-1.js
+++ b/tests/scroll-animations-1.js
@@ -56,4 +56,42 @@ export default {
 			],
 		},
 	},
+	interfaces: {
+		ScrollTimeline: {
+			links: {
+				tr: '#scrolltimeline',
+				dev: '#scrolltimeline',
+				mdnGroup: 'DOM',
+			},
+			tests: ['source', 'axis'],
+			interface: function() {
+				return new ScrollTimeline({
+					source: document.scrollingElement,
+				});
+			}
+		},
+		ViewTimeline: {
+			links: {
+				tr: '#viewtimeline',
+				dev: '#viewtimeline',
+				mdnGroup: 'DOM',
+			},
+			tests: ['subject', 'startOffset', 'endOffset'],
+			interface: function() {
+				return new ViewTimeline({
+					source: document.scrollingElement,
+				});
+			}
+		},
+		AnimationTimeline: {
+			links: {
+				dev: '#named-range-get-time',
+				mdnGroup: 'DOM',
+			},
+			tests: ['getCurrentTime'],
+			interface: function() {
+				return document.timeline;
+			},
+		},
+	},
 };

--- a/tests/web-animations-1.js
+++ b/tests/web-animations-1.js
@@ -1,0 +1,160 @@
+export default {
+	title: 'Web Animations',
+	links: {
+		tr: 'web-animations-1',
+		dev: 'web-animations-1',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	interfaces: {
+		Animation: {
+			links: {
+				tr: '#the-animation-interface',
+				dev: '#the-animation-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'id',
+				'effect',
+				'timeline',
+				'startTime',
+				'currentTime',
+				'playbackRate',
+				'playState',
+				'replaceState',
+				'pending',
+				'ready',
+				'finished',
+				'onfinish',
+				'oncancel',
+				'onremove',
+				'cancel',
+				'finish',
+				'play',
+				'pause',
+				'updatePlaybackRate',
+				'reverse',
+				'persist',
+				'commitStyles',
+				'addEventListener',
+				'removeEventListener',
+				'dispatchEvent',
+			],
+			interface: function() {
+				var div = document.createElement('div');
+				var keyFrames = new KeyframeEffect(
+					div,
+					[
+						{ transform: 'translateY(0%)' },
+						{ transform: 'translateY(100%)' }
+					],
+					{ duration: 3000, fill: 'forwards' }
+				)
+				return new Animation(keyFrames, document.timeline);
+			}
+		},
+		AnimationTimeline: {
+			links: {
+				tr: '#the-animationtimeline-interface',
+				dev: '#the-animationtimeline-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['currentTime'],
+			interface: function() {
+				return document.timeline;
+			}
+		},
+		AnimationEffect: {
+			links: {
+				tr: '#animationeffect',
+				dev: '#animationeffect',
+				mdnGroup: 'DOM',
+			},
+			tests: ['getTiming', 'getComputedTiming', 'updateTiming'],
+			interface: function() {
+				var div = document.createElement('div');
+				return new KeyframeEffect(
+					div,
+					[
+						{ transform: "translateY(0%)" },
+						{ transform: "translateY(100%)" },
+					],
+					{ duration: 3000, fill: "forwards" }
+				);
+			}
+		},
+		KeyframeEffect: {
+			links: {
+				tr: '#the-keyframeeffect-interface',
+				dev: '#the-keyframeeffect-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'target',
+				'pseudoElement',
+				'composite',
+				'getKeyframes',
+				'setKeyframes',
+				'getTiming',
+				'getComputedTiming',
+				'updateTiming',
+			],
+			interface: function() {
+				var div = document.createElement('div');
+				return new KeyframeEffect(
+					div,
+					[
+						{ transform: "translateY(0%)" },
+						{ transform: "translateY(100%)" },
+					],
+					{ duration: 3000, fill: "forwards" }
+				);
+			}
+		},
+		Element: {
+			links: {
+				tr: '#the-animatable-interface-mixin',
+				dev: '#the-animatable-interface-mixin',
+				mdnGroup: 'DOM',
+			},
+			tests: ['animate', 'getAnimations'],
+			interface: function() {
+				return document.body;
+			}
+		},
+		Document: {
+			links: {
+				tr: '#extensions-to-the-documentorshadowroot-interface-mixin',
+				dev: '#extensions-to-the-documentorshadowroot-interface-mixin',
+				mdnGroup: 'DOM',
+			},
+			tests: ['timeline', 'getAnimations'],
+			interface: function() {
+				return document;
+			}
+		},
+		DocumentTimeline: {
+			links: {
+				tr: '#the-documenttimeline-interface',
+				dev: '#the-documenttimeline-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['currentTime'],
+			interface: function() {
+				return document.timeline;
+			}
+		},
+		AnimationPlaybackEvent: {
+			links: {
+				tr: '#the-animationplaybackevent-interface',
+				dev: '#the-animationplaybackevent-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['currentTime', 'timelineTime'],
+			interface: function() {
+				return new AnimationPlaybackEvent('finish');
+			},
+		},
+	},
+};

--- a/tests/web-animations-2.js
+++ b/tests/web-animations-2.js
@@ -1,0 +1,170 @@
+export default {
+	title: 'Web Animations Level 2',
+	links: {
+		tr: 'web-animations-2',
+		dev: 'web-animations-2',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	interfaces: {
+		AnimationTimeline: {
+			links: {
+				tr: '#the-animationtimeline-interface',
+				dev: '#the-animationtimeline-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['duration', 'play'],
+			interface: function() {
+				return document.timeline;
+			}
+		},
+		AnimationEffect: {
+			links: {
+				tr: '#the-animationeffect-interface',
+				dev: '#the-animationeffect-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'parent',
+				'previousSibling',
+				'nextSibling',
+				'before',
+				'after',
+				'replace',
+				'remove'
+			],
+			interface: function() {
+				var div = document.createElement('div');
+				return new KeyframeEffect(
+					div,
+					[
+						{ transform: "translateY(0%)" },
+						{ transform: "translateY(100%)" },
+					],
+					{ duration: 3000, fill: "forwards" }
+				);
+			}
+		},
+		GroupEffect: {
+			links: {
+				tr: '#the-groupeffect-interface',
+				dev: '#the-groupeffect-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'children',
+				'firstChild',
+				'lastChild',
+				'clone',
+				'prepend',
+				'append',
+			],
+			interface: function() {
+				var div = document.createElement('div');
+				return new GroupEffect(
+					new KeyframeEffect(
+						div,
+						[
+							{ transform: "translateY(0%)" },
+							{ transform: "translateY(100%)" },
+						],
+						{ duration: 3000, fill: "forwards" }
+					),
+					new KeyframeEffect(
+						div,
+						[
+							{ opacity: 0 },
+							{ opacity: 1 },
+						],
+						{ duration: 3000, fill: "forwards" }
+					),
+				);
+			}
+		},
+		AnimationNodeList: {
+			links: {
+				tr: '#the-animationnodelist-interface',
+				dev: '#the-animationnodelist-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['length', 'item'],
+			interface: function() {
+				var div = document.createElement('div');
+				return new GroupEffect(
+					new KeyframeEffect(
+						div,
+						[
+							{ transform: "translateY(0%)" },
+							{ transform: "translateY(100%)" },
+						],
+						{ duration: 3000, fill: "forwards" }
+					),
+					new KeyframeEffect(
+						div,
+						[
+							{ opacity: 0 },
+							{ opacity: 1 },
+						],
+						{ duration: 3000, fill: "forwards" }
+					),
+				).children;
+			}
+		},
+		SequenceEffect: {
+			links: {
+				tr: '#the-sequenceeffect-interface',
+				dev: '#the-sequenceeffect-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: [
+				'children',
+				'firstChild',
+				'lastChild',
+				'clone',
+				'prepend',
+				'append',
+			],
+			interface: function() {
+				var div = document.createElement('div');
+				return new SequenceEffect(
+					new KeyframeEffect(
+						div,
+						[
+							{ transform: "translateY(0%)" },
+							{ transform: "translateY(100%)" },
+						],
+						{ duration: 3000, fill: "forwards" }
+					),
+					new KeyframeEffect(
+						div,
+						[
+							{ opacity: 0 },
+							{ opacity: 1 },
+						],
+						{ duration: 3000, fill: "forwards" }
+					),
+				);
+			}
+		},
+		KeyframeEffect: {
+			links: {
+				tr: '#the-keyframeeffect-interface',
+				dev: '#the-keyframeeffect-interface',
+				mdnGroup: 'DOM',
+			},
+			tests: ['iteratonComposite'],
+			interface: function() {
+				var div = document.createElement('div');
+				return new KeyframeEffect(
+					div,
+					[
+						{ transform: "translateY(0%)" },
+						{ transform: "translateY(100%)" },
+					],
+					{ duration: 3000, fill: "forwards" }
+				);
+			}
+		},
+	},
+};


### PR DESCRIPTION
I've added the methods `interface` and `attributeOrMethod` that check for DOM feature support.

Based on this new functionality, I've added all the DOM API feature and event checks I could find for the different specs. I probably missed a few features, though I believe that's a good start.

Note that with this addition I could also add a bunch of new specs which previously weren't covered because they only (or mostly) define DOM APIs.

This fixes #211.

Sebastian