### PR TITLE
Added filter for standardization groups

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -462,6 +462,16 @@ window.runTests = function (filter = '') {
 			}
 		} else if (filter === '' && Specs[spec].status && Specs[spec].status['first-snapshot'] === 1998) {
 			continue;
+		} else if (filter === 'csswg' && Specs[spec].links.devtype && !Specs[spec].links.devtype.match(/fxtf/)) {
+			continue;
+		} else if (filter === 'houdini' && (!('devtype' in Specs[spec].links) || !Specs[spec].links.devtype.match(/houdini/))) {
+			continue;
+		} else if (filter === 'svgwg' && Specs[spec].links.devtype !== 'svgwg') {
+			continue;
+		} else if (filter === 'whatwg' && Specs[spec].links.devtype !== 'whatwg') {
+			continue;
+		} else if (filter === 'others' && (!('devtype' in Specs[spec].links) || Specs[spec].links.devtype.match(/fxtf|houdini|svgwg|whatwg/))) {
+			continue;
 		}
 
 		specs.push({

--- a/index.html
+++ b/index.html
@@ -43,6 +43,13 @@
 				<option value="all" title="All specifications including experimental ones">All</option>
 				<option value="stable" title="All specifications listed in the latest CSS snapshot, their predecessors and others that won't change much anymore">Stable</option>
 				<option value="experimental" title="All specifications not listed in the latest CSS snapshot">Experimental</option>
+				<optgroup label="Standardization groups">
+					<option value="csswg" title="All specifications managed by the CSS Working Group (CSSWG) except CSS Houdini">CSS</option>
+					<option value="houdini" title="All specifications related to CSS Houdini managed by the CSS Working Group (CSSWG)">CSS Houdini</option>
+					<option value="svgwg" title="All specifications managed by the SVG Working Group (SVGWG)">SVG</option>
+					<option value="whatwg" title="All specifications managed by the Web Hypertext Application Technology Working Group (WHATWG)">WHATWG</option>
+					<option value="others" title="All specifications managed by other standardization groups">Others</option>
+				</optgroup>
 				<optgroup label="CSS snapshots">
 					<option value="1998" title="Everything included in CSS 2.2">CSS 2.2</option>
 					<option value="2007" title="All specifications marked as official part of the CSS 2007 snapshot">CSS 2007</option>


### PR DESCRIPTION
I've added a new filter group for "standardization groups" including CSS, CSS Houdini (also CSSWG but separate enough to justify being listed individually), SVG, WHATWG and others.

This fixes #240.

Sebastian