### PR TITLE
Fixed checks of pseudo-element selectors

### DIFF
--- a/supports.js
+++ b/supports.js
@@ -139,14 +139,13 @@
 			for (var i = 0; i < _.prefixes.length; i++) {
 				var prefixed = selector.replace(/^(:+)/, '$1' + _.prefixes[i]);
 
-				try {
-					document.querySelector(prefixed);
+				if (CSS.supports('selector(' + prefixed + ')')) {
 					_.selector.cached[selector] = true;
 					return {
 						success: true,
-						propertyPrefix: _.prefixes[i],
+						prefix: _.prefixes[i],
 					};
-				} catch (e) {}
+				}
 			}
 
 			_.selector.cached[selector] = false;


### PR DESCRIPTION
Pseudo-elements containing `-webkit-` as prefix have to be considered valid as parse time for web compatibililty. So support is now tested using `CSS.supports()` with the `selector()` function instead of `document.querySelector()`.

Note that [support for the `selector()` function is at 95% at caniuse.com](https://caniuse.com/mdn-css_at-rules_supports_selector), so this change causes some (older) browser versions to generally fail selector tests. Though I believe the advantage of getting it right for current browsers outweighs this.

This fixes #253.

Sebastian