### PR TITLE
Added WebXR DOM Overlays

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -43,6 +43,9 @@ var devLinkFormat = function (params) {
 			return 'https://drafts.css-houdini.org/' + params.dev;
 		case 'github':
 			return 'https://w3c.github.io/' + params.dev;
+		case 'iwwg':
+			// The Immersive Web Working Group
+			return 'https://immersive-web.github.io/' + params.dev;
 		case 'svgwg':
 			// SVG Working Group Editor Drafts
 			return 'https://svgwg.org/' + params.dev;

--- a/tests.js
+++ b/tests.js
@@ -149,6 +149,7 @@ import svg2Text from './tests/svg2-text.js';
 import webAnimations1 from './tests/web-animations-1.js';
 import webAnimations2 from './tests/web-animations-2.js';
 import webVtt from './tests/webvtt.js';
+import webxrDomOverlays1 from './tests/webxr-dom-overlays-1.js';
 
 
 export default {
@@ -303,4 +304,5 @@ export default {
 	'web-animations-1': webAnimations1,
 	'web-animations-2': webAnimations2,
 	webvtt: webVtt,
+	'webxr-dom-overlays-1': webxrDomOverlays1,
 };

--- a/tests/webxr-dom-overlays-1.js
+++ b/tests/webxr-dom-overlays-1.js
@@ -1,0 +1,20 @@
+export default {
+	title: 'WebXR DOM Overlays Module',
+	links: {
+		tr: 'webxr-dom-overlays-1',
+		dev: 'dom-overlays',
+		devtype: 'iwwg',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	selectors: {
+		':xr-overlay': {
+			links: {
+				tr: '#css-pseudo-class',
+				dev: '#css-pseudo-class',
+			},
+			tests: [':xr-overlay'],
+		},
+	},
+};


### PR DESCRIPTION
Though https://github.com/LeaVerou/css3test/pull/255 I realized that there's a [WebXR DOM Overlays spec.](https://immersive-web.github.io/dom-overlays/) defining an `:xr-overlay` pseudo-class. So I've added the spec. plus linking reference info and the text for the pseudo-class.

A quick check did not show any other points of contact with CSS. Though if more things are defined in those Immersive Web specs, we may add them later.

Sebastian

