### PR TITLE
[css-gradient]: allow a single color stop with 0-1 positions

### DIFF
--- a/tests/css-images-3.js
+++ b/tests/css-images-3.js
@@ -18,12 +18,21 @@ export default {
 			tests: [
 				'linear-gradient(white, black)',
 				'linear-gradient(to right, white, black)',
+				'linear-gradient(0, white, black)',
 				'linear-gradient(45deg, white, black)',
 				'linear-gradient(white 50%, black)',
 				'linear-gradient(white 5px, black)',
 				'linear-gradient(white, #f06, black)',
 				'linear-gradient(currentColor, black)',
 				'linear-gradient(red -50px, white calc(-25px + 50%), blue 100%)',
+
+				'linear-gradient(red 0 0)',
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
+				'linear-gradient(red)',
+				'linear-gradient(red 0)',
+				'linear-gradient(red 50px)',
+				'linear-gradient(0, red)',
 			],
 		},
 		'radial-gradient()': {
@@ -39,12 +48,24 @@ export default {
 				'radial-gradient(circle closest-corner, white, black)',
 				'radial-gradient(farthest-side, white, black)',
 				'radial-gradient(circle farthest-side, white, black)',
+				'radial-gradient(0, white, black)',
 				'radial-gradient(50%, white, black)',
 				'radial-gradient(60% 60%, white, black)' /*,
 				"radial-gradient(at 60% 60%, white, black)",
 				"radial-gradient(30% 30% at 20% 20%, white, black)",
 				"radial-gradient(5em circle at top left, yellow, blue)",
 				"radial-gradient(circle farthest-side at top left, white, black)"*/,
+
+				'radial-gradient(red 0 0)',
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
+				'radial-gradient(red)',
+				'radial-gradient(red 0)',
+				'radial-gradient(red 50px)',
+				'radial-gradient(0%, red)',
+				'radial-gradient(50% 60%, red)',
+				'radial-gradient(circle, red)',
+				'radial-gradient(circle closest-corner, red)',
 			],
 		},
 		'repeating-linear-gradient()': {
@@ -52,14 +73,22 @@ export default {
 				tr: '#repeating-gradients',
 				dev: '#repeating-gradients',
 			},
-			tests: 'repeating-linear-gradient(white, black)',
+			tests: [
+				'repeating-linear-gradient(red)',
+				'repeating-linear-gradient(red 0 0)',
+				'repeating-linear-gradient(white, black)',
+			],
 		},
 		'repeating-radial-gradient()': {
 			links: {
 				tr: '#repeating-gradients',
 				dev: '#repeating-gradients',
 			},
-			tests: 'repeating-radial-gradient(white, black)',
+			tests: [
+				'repeating-radial-gradient(red)',
+				'repeating-radial-gradient(red 0 0)',
+				'repeating-radial-gradient(white, black)',
+			]
 		},
 	},
 	properties: {

--- a/tests/css-images-3.js
+++ b/tests/css-images-3.js
@@ -26,7 +26,6 @@ export default {
 				'linear-gradient(currentColor, black)',
 				'linear-gradient(red -50px, white calc(-25px + 50%), blue 100%)',
 
-				'linear-gradient(red 0 0)',
 				// allow a single color stop with 0-1 positions
 				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
 				'linear-gradient(red)',
@@ -56,7 +55,6 @@ export default {
 				"radial-gradient(5em circle at top left, yellow, blue)",
 				"radial-gradient(circle farthest-side at top left, white, black)"*/,
 
-				'radial-gradient(red 0 0)',
 				// allow a single color stop with 0-1 positions
 				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
 				'radial-gradient(red)',
@@ -75,7 +73,6 @@ export default {
 			},
 			tests: [
 				'repeating-linear-gradient(red)',
-				'repeating-linear-gradient(red 0 0)',
 				'repeating-linear-gradient(white, black)',
 			],
 		},
@@ -86,7 +83,6 @@ export default {
 			},
 			tests: [
 				'repeating-radial-gradient(red)',
-				'repeating-radial-gradient(red 0 0)',
 				'repeating-radial-gradient(white, black)',
 			]
 		},

--- a/tests/css-images-4.js
+++ b/tests/css-images-4.js
@@ -165,6 +165,12 @@ export default {
 				"image-set(url(foobar.png) type('image/png'))",
 				"image-set(url(foobar.png) 1x type('image/png'))",
 				"image-set(url(foobar.png) type('image/png') 1x)",
+
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
+				'image-set(linear-gradient(green))',
+				'image-set(radial-gradient(green))',
+				'image-set(conic-gradient(green))',
 			],
 		},
 		'element()': {
@@ -183,6 +189,9 @@ export default {
 				'cross-fade(url(a.png), url(b.png))',
 				'cross-fade(url(a.png) 50%, url(b.png))',
 				'cross-fade(url(a.png) 50%, white)',
+				'cross-fade(linear-gradient(green))',
+				'cross-fade(radial-gradient(green))',
+				'cross-fade(conic-gradient(green))',
 			],
 		},
 	},

--- a/tests/css-images-4.js
+++ b/tests/css-images-4.js
@@ -45,7 +45,8 @@ export default {
 				'linear-gradient(in lch, red)',
 				'linear-gradient(in lab, red 0)',
 				'linear-gradient(in oklab to right, red 50px)',
-				'linear-gradient(in hsl shorter hue, red)',
+				'linear-gradient(in hsl longer hue, red)',
+				'linear-gradient(90deg in hsl longer hue, red)',
 			],
 		},
 		'radial-gradient()': {
@@ -72,7 +73,7 @@ export default {
 				'radial-gradient(in lch, red)',
 				'radial-gradient(in lab, red 0)',
 				'radial-gradient(in oklab at 50%, red 50px)',
-				'radial-gradient(in hsl shorter hue, red)',
+				'radial-gradient(in hsl longer hue, red)',
 			],
 		},
 		'conic-gradient()': {
@@ -90,11 +91,6 @@ export default {
 				'conic-gradient(white, #f06, black)',
 				'conic-gradient(currentColor, black)',
 				'conic-gradient(black 25%, white 0deg 50%, black 0deg 75%, white 0deg)',
-
-				'conic-gradient(red 0 0)',
-				'conic-gradient(red 90deg 50%)',
-				'conic-gradient(from 0, red 0 0)',
-				'conic-gradient(from 20deg, red 45deg 20%)',
 
 				// allow a single color stop with 0-1 positions
 				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
@@ -124,6 +120,7 @@ export default {
 				'conic-gradient(in lab, red)',
 				'conic-gradient(from 45deg in lch, red 0)',
 				'conic-gradient(in oklab at top left, red 50%)',
+				'conic-gradient(in hsl longer hue, red)',
 				'conic-gradient(in hsl shorter hue from 45deg, red 90deg)',
 				'conic-gradient(from 0 in srgb, red)',
 			],
@@ -189,6 +186,9 @@ export default {
 				'cross-fade(url(a.png), url(b.png))',
 				'cross-fade(url(a.png) 50%, url(b.png))',
 				'cross-fade(url(a.png) 50%, white)',
+
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
 				'cross-fade(linear-gradient(green))',
 				'cross-fade(radial-gradient(green))',
 				'cross-fade(conic-gradient(green))',

--- a/tests/css-images-4.js
+++ b/tests/css-images-4.js
@@ -39,6 +39,13 @@ export default {
 				'linear-gradient(in hsl longer hue to right, #A37, #595)',
 				'linear-gradient(in hsl increasing hue to right, #A37, #595)',
 				'linear-gradient(in hsl decreasing hue to right, #A37, #595)',
+
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
+				'linear-gradient(in lch, red)',
+				'linear-gradient(in lab, red 0)',
+				'linear-gradient(in oklab to right, red 50px)',
+				'linear-gradient(in hsl shorter hue, red)',
 			],
 		},
 		'radial-gradient()': {
@@ -60,6 +67,12 @@ export default {
 				'radial-gradient(in srgb farthest-side at left bottom, color(display-p3 0.918 0.2 0.161), #081)',
 				'radial-gradient(in oklab farthest-side at left bottom, color(display-p3 0.918 0.2 0.161), #081)',
 				'radial-gradient(in hsl shorter hue at left bottom, color(display-p3 0.918 0.2 0.161), #081)',
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
+				'radial-gradient(in lch, red)',
+				'radial-gradient(in lab, red 0)',
+				'radial-gradient(in oklab at 50%, red 50px)',
+				'radial-gradient(in hsl shorter hue, red)',
 			],
 		},
 		'conic-gradient()': {
@@ -69,6 +82,7 @@ export default {
 			},
 			tests: [
 				'conic-gradient(white, black)',
+				'conic-gradient(from 0, white, black)',
 				'conic-gradient(from 5deg, white, black)',
 				'conic-gradient(at top left, white, black)',
 				'conic-gradient(white 50%, black)',
@@ -76,6 +90,19 @@ export default {
 				'conic-gradient(white, #f06, black)',
 				'conic-gradient(currentColor, black)',
 				'conic-gradient(black 25%, white 0deg 50%, black 0deg 75%, white 0deg)',
+
+				'conic-gradient(red 0 0)',
+				'conic-gradient(red 90deg 50%)',
+				'conic-gradient(from 0, red 0 0)',
+				'conic-gradient(from 20deg, red 45deg 20%)',
+
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
+				'conic-gradient(red)',
+				'conic-gradient(red 0)',
+				'conic-gradient(red 50%)',
+				'conic-gradient(red 90deg)',
+				'conic-gradient(from 0, red)',
 			],
 		},
 		'conic-gradient() color interpolation': {
@@ -91,6 +118,14 @@ export default {
 				'conic-gradient(in srgb from 45deg, white, black, white)',
 				'conic-gradient(in oklab at top left, white, black, white)',
 				'conic-gradient(in hsl shorter hue from 45deg, white, black, white)',
+
+				// allow a single color stop with 0-1 positions
+				// https://github.com/w3c/csswg-drafts/issues/10092#issuecomment-2145860054
+				'conic-gradient(in lab, red)',
+				'conic-gradient(from 45deg in lch, red 0)',
+				'conic-gradient(in oklab at top left, red 50%)',
+				'conic-gradient(in hsl shorter hue from 45deg, red 90deg)',
+				'conic-gradient(from 0 in srgb, red)',
 			],
 		},
 		'repeating-conic-gradient()': {


### PR DESCRIPTION
- [Safari TP 213](https://webkit.org/blog/16461/release-notes-for-safari-technology-preview-213/) https://github.com/WebKit/WebKit/pull/39545
- Firefox 136: https://bugzilla.mozilla.org/show_bug.cgi?id=1900530
- Chrome 135: https://chromium-review.googlesource.com/c/chromium/src/+/6197018