### PR TITLE
Added CSS Forms 1

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -42,6 +42,7 @@ import cssFontLoading3 from './tests/css-font-loading-3.js';
 import cssFonts3 from './tests/css-fonts-3.js';
 import cssFonts4 from './tests/css-fonts-4.js';
 import cssFonts5 from './tests/css-fonts-5.js';
+import cssForms1 from './tests/css-forms-1.js';
 import cssGaps1 from './tests/css-gaps-1.js';
 import cssGrid1 from './tests/css-grid-1.js';
 import cssGrid2 from './tests/css-grid-2.js';
@@ -212,6 +213,7 @@ export default {
 	'css-fonts-3': cssFonts3,
 	'css-fonts-4': cssFonts4,
 	'css-fonts-5': cssFonts5,
+	'css-forms-1': cssForms1,
 	'css-gaps-1': cssGaps1,
 	'css-grid-1': cssGrid1,
 	'css-grid-2': cssGrid2,

--- a/tests/css-forms-1.js
+++ b/tests/css-forms-1.js
@@ -1,0 +1,163 @@
+export default {
+	title: 'CSS Form Control Styling Level 1',
+	links: {
+		tr: 'css-forms-1',
+		dev: 'css-forms-1',
+	},
+	status: {
+		stability: 'experimental',
+	},
+	values: {
+		properties: ['content', 'color', 'line-height'],
+		'control-value()': {
+			links: {
+				tr: '#control-value',
+				dev: '#control-value',
+			},
+			tests: ['control-value()'],
+		},
+	},
+	properties : {
+		'appearance': {
+			links: {
+				tr: '#appearance',
+				dev: '#appearance',
+			},
+			tests: ['base'],
+		},
+		'slider-orientation': {
+			links: {
+				tr: '#slider-orientation',
+				dev: '#slider-orientation',
+			},
+			tests: [
+				'auto',
+				'left-to-right',
+				'right-to-left',
+				'top-to-bottom',
+				'bottom-to-top',
+			],
+		}
+	},
+	selectors: {
+		'::picker()': {
+			links: {
+				tr: '#picker-pseudo',
+				dev: '#picker-pseudo',
+			},
+			tests: ['::picker(select)'],
+		},
+		'::picker-icon': {
+			links: {
+				tr: '#picker-icon',
+				dev: '#picker-icon',
+			},
+			tests: ['::picker-icon'],
+		},
+		'::checkmark': {
+			links: {
+				tr: '#checkmark',
+				dev: '#checkmark',
+			},
+			tests: ['::checkmark'],
+		},
+		'::thumb': {
+			links: {
+				tr: '#slider-pseudos',
+				dev: '#slider-pseudos',
+			},
+			tests: ['::thumb'],
+		},
+		'::track': {
+			links: {
+				tr: '#slider-pseudos',
+				dev: '#slider-pseudos',
+			},
+			tests: ['::track'],
+		},
+		'::fill': {
+			links: {
+				tr: '#slider-pseudos',
+				dev: '#slider-pseudos',
+			},
+			tests: ['::fill'],
+		},
+		'::field-text': {
+			links: {
+				tr: '#field-pseudos',
+				dev: '#field-pseudos',
+			},
+			tests: ['::field-text'],
+		},
+		'::clear-icon': {
+			links: {
+				tr: '#field-pseudos',
+				dev: '#field-pseudos',
+			},
+			tests: ['::clear-icon'],
+		},
+		'::step-control': {
+			links: {
+				tr: '#number-pseudos',
+				dev: '#number-pseudos',
+			},
+			tests: ['::step-control'],
+		},
+		'::step-up': {
+			links: {
+				tr: '#number-pseudos',
+				dev: '#number-pseudos',
+			},
+			tests: ['::step-up'],
+		},
+		'::step-down': {
+			links: {
+				tr: '#number-pseudos',
+				dev: '#number-pseudos',
+			},
+			tests: ['::step-down'],
+		},
+		'::field-component': {
+			links: {
+				tr: '#date-time-pseudos',
+				dev: '#date-time-pseudos',
+			},
+			tests: ['::field-component'],
+		},
+		'::field-separator': {
+			links: {
+				tr: '#date-time-pseudos',
+				dev: '#date-time-pseudos',
+			},
+			tests: ['::field-separator'],
+		},
+		'::color-swatch': {
+			links: {
+				tr: '#color-swatch-pseudo',
+				dev: '#color-swatch-pseudo',
+			},
+			tests: ['::color-swatch'],
+		},
+		':low-value': {
+			links: {
+				tr: '#meter-values',
+				dev: '#meter-values',
+			},
+			tests: [':low-value'],
+		},
+		':high-value': {
+			links: {
+				tr: '#meter-values',
+				dev: '#meter-values',
+			},
+			tests: [':high-value'],
+		},
+		':optimal-value': {
+			links: {
+				tr: '#meter-values',
+				dev: '#meter-values',
+			},
+			tests: [':optimal-value'],
+		},
+	},
+};


### PR DESCRIPTION
I've added the CSS Forms 1 spec. It's still in an early stage, though it already has a FPWD and parts of it already got released in Chromium-based browsers.

I wasn't sure whether to add the test for `appearance: base` as property or as value test. I decided to go with a property test as it only applies to a single property. Though please let me know if you think differently!
The other features should also get double-checked if the tests are correct.

Sebastian