### PR TITLE
Updated CSS Color 6

### DIFF
--- a/tests/css-color-6.js
+++ b/tests/css-color-6.js
@@ -8,14 +8,22 @@ export default {
 	},
 	values: {
 		properties: ['color', 'background-color', 'border-color', 'text-decoration-color', 'column-rule-color'],
-		'color-contrast()': {
+		'contrast-color()': {
 			links: {
 				dev: '#colorcontrast',
-				mdn: 'color_value/color-contrast',
+				mdn: 'color_value/contrast-color',
 			},
 			tests: [
-				'color-contrast(wheat vs tan, sienna, #b22222, #d2691e)',
-				'color-contrast(hsl(200 50% 80%) vs hsl(200 83% 23%), purple, hsl(300 100% 25%))',
+				'contrast-color(wheat tbd-fg)',
+				'contrast-color(wheat tbd-bg)',
+				'contrast-color(wheat tbd-bg wcag2))',
+				'contrast-color(wheat tbd-bg wcag2(4.2))',
+				'contrast-color(wheat tbd-bg wcag2(aa))',
+				'contrast-color(wheat tbd-bg wcag2(aaa))',
+				'contrast-color(wheat tbd-bg wcag2(aa large))',
+				'contrast-color(wheat tbd-bg wcag2(aaa large))',
+				'contrast-color(wheat tbd-bg wcag2(aa), tan, sienna, #b22222, #d2691e)',
+				'contrast-color(hsl(200 50% 80%) tbd-bg wcag2(aa), hsl(200 83% 23%), purple, hsl(300 100% 25%))',
 			],
 		},
 		'color-layers()': {
@@ -24,13 +32,12 @@ export default {
 				mdn: 'color_value/color-layers',
 			},
 			tests: [
-				'color-layers(rgb(from yellow r g b / 0.5))',
-				'color-layers(rgb(from yellow r g b / 0.5), red)',
-				'color-layers(rgb(from yellow r g b / 0.5), color(display-p3 1 0.5 0))',
-				'color-layers(rgb(from yellow r g b / 0.5), color-mix(in lab, red, blue))',
-				'color-layers(rgb(from yellow r g b / 0.5), rgba(0, 255, 128, 0.6), currentcolor, hsla(0, 100%, 20%, 0.4))',
-				'color-layers(rgb(from yellow r g b / 0.5), rgba(0, 255, 128, 0.6), color-mix(in lab, purple, rgba(0,0,0,0.5)), color(display-p3 1 0.5 0))',
-				'color-layers(color(display-p3 1 0.5 0), rgb(from yellow r g b / 0.5), rgba(0, 255, 128, 0.6), color-mix(in lab, purple, rgba(0,0,0,0.5)), hsla(0, 100%, 20%, 0.4))'
+				'color-layers(wheat)',
+				'color-layers(wheat, red)',
+				'color-layers(wheat, color(display-p3 1 0.5 0))',
+				'color-layers(wheat, currentcolor, #000)',
+				'color-layers(multiply, wheat)',
+				'color-layers(lighten, wheat)',
 			],
 		},
 	},


### PR DESCRIPTION
I've updated CSS Color 6 to the latest draft (including the `tbd-fg` and `tbd-bg` keywords, which obviously are just placeholders). Also, the MDN links are non-existent at the moment.

Though I wonder whether we should remove it again for now, given it still has a big banner saying "Not Ready For Implementation".

So, @LeaVerou, @svgeesus, what do you think?

Sebastian