### PR TITLE
Added heading anchor links

### DIFF
--- a/csstest.js
+++ b/csstest.js
@@ -126,6 +126,17 @@ var Test = function (spec) {
 				}),
 			);
 		}
+
+		contents.push(
+			$.create({
+				tag: 'a',
+				properties: {
+					href: '#' + spec.id,
+					textContent: '#',
+					className: 'section-link',
+				},
+			}),
+		);
 	}
 
 	var h1 = $.create({

--- a/style.css
+++ b/style.css
@@ -107,6 +107,11 @@ h2 {
 	display: flex;
 	align-items: center;
 	font-size: 180%;
+	position: relative;
+}
+
+#content > section section section h1:hover > .section-link {
+	display: block;
 }
 
 #content > section section section section h1 {
@@ -178,6 +183,14 @@ details summary > .spec-link::before {
 	width: 18px;
 	background-size: 18px 18px;
 	vertical-align: -4px;
+}
+
+.section-link {
+	display: none;
+	position: absolute;
+	left: calc(-1 * 1.2em);
+	width: 1.2em;
+	text-align: center;
 }
 
 body > h1 {


### PR DESCRIPTION
Added anchor links to the headings of tested specs. This allows to jump to the specs and copy their anchor. The anchor links are only shown when hovering the related heading.

Fixes #276

Sebastian